### PR TITLE
Fix CORS issues with devServer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git@github.com:DependencyTrack/front-end.git"
   },
   "scripts": {
+    "start": "npm run serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"

--- a/src/shared/api.js
+++ b/src/shared/api.js
@@ -3,7 +3,8 @@
  * All API calls to the Dependency-Track server should make use of these constants in order to
  * avoid typographical errors.
  */
-const BASE_URL = process.env.VUE_APP_SERVER_URL;
+const BASE_URL =
+  process.env.NODE_ENV === "production" ? process.env.VUE_APP_SERVER_URL : "";
 
 const CONTENT_TYPE_JSON = "application/json";
 const ENCODE_MULTIPART_FORM_DATA = "multipart/form-data";

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   lintOnSave: false,
   runtimeCompiler: true,
-  publicPath: '/'
-}
+  publicPath: "/",
+  devServer: {
+    proxy: { "/api": { target: process.env.VUE_APP_SERVER_URL } }
+  }
+};


### PR DESCRIPTION
* Proxy API requests to the backend when using devServer.
* When developing, use relative paths for API requests. In production use absolute URIs for API requests.
* Add npm start script which starts the devServer