### PR TITLE
Check authorization status on application initialization

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@
             }
           });
         })
-        .catch((err) => {
+        .catch(() => {
           // Token is stale, clear stored token and redirect to login view
           sessionStorage.removeItem('token');
           this.$router.replace({ name: "Login" });

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -6,7 +6,7 @@
           <b-card-group>
             <b-card no-body class="p-4">
               <b-card-body>
-                <b-form @submit.prevent="login()">
+                <b-form @submit.prevent.stop="login()">
                   <h1>{{ $t('message.login') }}</h1>
                   <p class="text-muted">{{ $t('message.login_desc') }}</p>
                   <b-input-group class="mb-3">
@@ -19,7 +19,7 @@
                   </b-input-group>
                   <b-row>
                     <b-col cols="6">
-                      <b-button variant="primary" type="submit" class="px-4" v-on:click="login()">{{ $t('message.login') }}</b-button>
+                      <b-button variant="primary" type="submit" class="px-4">{{ $t('message.login') }}</b-button>
                     </b-col>
                   </b-row>
                 </b-form>

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -42,6 +42,8 @@
 
 <script>
   import axios from 'axios'
+  // bootstrap-table still relies on jQuery for ajax calls, even though there's a supported Vue wrapper for it.
+  import $ from 'jquery'
   import api from '../../shared/api';
   import InformationalModal from '../modals/InformationalModal'
   const qs = require('querystring');
@@ -77,6 +79,13 @@
           .then((result) => {
             if(result.statusText === 'OK') {
               sessionStorage.setItem('token', result.data); // store the JWT in session storage
+              // Set authorization headers for axios and jQuery
+              axios.defaults.headers.common['Authorization'] = `Bearer ${result.data}`; 
+              $.ajaxSetup({
+                beforeSend: function(xhr) {
+                  xhr.setRequestHeader("Authorization", `Bearer ${result.data}`);
+                }
+              });
               this.$router.replace({ name: "Dashboard" });
             }
           })

--- a/src/views/portfolio/projects/Projects.vue
+++ b/src/views/portfolio/projects/Projects.vue
@@ -114,26 +114,8 @@ export default {
         search: true,
         showColumns: true,
         url: `${api.BASE_URL}/${api.URL_PROJECT}`,
-        ajaxOptions: {
-          beforeSend: function(xhr) {
-            xhr.setRequestHeader(
-              "Authorization",
-              `Bearer ${sessionStorage.getItem("token")}`
-            );
-          }
-        }
       }
     };
-    // mounted() {
-    //   axios
-    //     .get(`${api.BASE_URL}/${api.URL_PROJECT}`, {
-    //       headers: { Authorization: `Bearer ${sessionStorage.getItem("token")}` }
-    //     })
-    //     .then(result => {
-    //       this.data = result.data;
-    //       console.log(this.data);
-    //     });
-    // }
   }
 };
 </script>


### PR DESCRIPTION
This PR adds functionality for checking the stored JWT token status during app init. Token status is checked by calling `v1/user/self` API to fetch user details. On a successful API response we set axios and jQuery authorization headers and proceed with routing etc. If an error occurs, we clear the session storage token and redirect to the login page.

Also changes successful login attempts to set the axios and jQuery authorization headers.

Fixes #8 