### PR TITLE
Prevent page reload on opening page project

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -80,7 +80,7 @@
               return `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
             },
             events: {
-              'click a': (e,value,row,index) => {
+              'click a': (e,value,row) => {
                 e.preventDefault();
                 this.$router.push({ name: "Project", params: { uuid: row.uuid }})
               }            

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -78,6 +78,12 @@
             formatter(value, row, index) {
               let url = xssFilters.uriInUnQuotedAttr("../projects/" + row.uuid);
               return `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
+            },
+            events: {
+              'click a': (e,value,row,index) => {
+                e.preventDefault();
+                this.$router.push({ name: "Project", params: { uuid: row.uuid }})
+              }            
             }
           },
           {


### PR DESCRIPTION
The link injected for project/uuid cannot be intercepted by vue-router, which causes a full page reload on click. Adding a custom event and using $router.push instead ensures the routing is done by vue-router and improve page transition.

**Suggestion :** Also, you might consider using the table component from bootsrap-vue instead bootstrap-table because it has better integration with Vue.js (custom slot definition) and will reduce your amount of dependencies for the frontend.