### PR TITLE
Reload audit trail after analysis modifications

### DIFF
--- a/src/views/portfolio/components/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/components/ComponentVulnerabilities.vue
@@ -199,29 +199,31 @@
                   let queryString = "?component=" + componentUuid + "&vulnerability=" + this.vulnerability.uuid;
                   let url = `${this.$api.BASE_URL}/${this.$api.URL_ANALYSIS}` + queryString;
                   this.axios.get(url).then((response) => {
-                    let analysis = response.data;
-                    if (Object.prototype.hasOwnProperty.call(analysis, "analysisComments")) {
-                      let trail = "";
-                      for (let i = 0; i < analysis.analysisComments.length; i++) {
-                        if (Object.prototype.hasOwnProperty.call(analysis.analysisComments[i], "commenter")) {
-                          trail += analysis.analysisComments[i].commenter + " - ";
-                        }
-                        trail += common.formatTimestamp(analysis.analysisComments[i].timestamp, true);
-                        trail += "\n";
-                        trail += analysis.analysisComments[i].comment;
-                        trail += "\n\n";
-                      }
-                      this.auditTrail = trail;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(analysis, "analysisState")) {
-                      this.analysisState = analysis.analysisState;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(analysis, "isSuppressed")) {
-                      this.isSuppressed = analysis.isSuppressed;
-                    } else {
-                      this.isSuppressed = false;
-                    }
+                    this.updateAnalysisData(response.data);
                   });
+                },
+                updateAnalysisData: function(analysis) {
+                  if (Object.prototype.hasOwnProperty.call(analysis, "analysisComments")) {
+                    let trail = "";
+                    for (let i = 0; i < analysis.analysisComments.length; i++) {
+                      if (Object.prototype.hasOwnProperty.call(analysis.analysisComments[i], "commenter")) {
+                        trail += analysis.analysisComments[i].commenter + " - ";
+                      }
+                      trail += common.formatTimestamp(analysis.analysisComments[i].timestamp, true);
+                      trail += "\n";
+                      trail += analysis.analysisComments[i].comment;
+                      trail += "\n\n";
+                    }
+                    this.auditTrail = trail;
+                  }
+                  if (Object.prototype.hasOwnProperty.call(analysis, "analysisState")) {
+                    this.analysisState = analysis.analysisState;
+                  }
+                  if (Object.prototype.hasOwnProperty.call(analysis, "isSuppressed")) {
+                    this.isSuppressed = analysis.isSuppressed;
+                  } else {
+                    this.isSuppressed = false;
+                  }
                 },
                 makeAnalysis: function() {
                   this.callRestEndpoint(this.analysisState, null, null);
@@ -241,6 +243,7 @@
                     isSuppressed: isSuppressed
                   }).then((response) => {
                     this.$toastr.s(this.$t('message.updated'));
+                    this.updateAnalysisData(response.data);
                   }).catch((error) => {
                     this.$toastr.w(this.$t('condition.unsuccessful_action'));
                   });

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -200,29 +200,31 @@
                   let queryString = "?project=" + projectUuid + "&component=" + this.finding.component.uuid + "&vulnerability=" + this.finding.vulnerability.uuid;
                   let url = `${this.$api.BASE_URL}/${this.$api.URL_ANALYSIS}` + queryString;
                   this.axios.get(url).then((response) => {
-                    let analysis = response.data;
-                    if (Object.prototype.hasOwnProperty.call(analysis, "analysisComments")) {
-                      let trail = "";
-                      for (let i = 0; i < analysis.analysisComments.length; i++) {
-                        if (Object.prototype.hasOwnProperty.call(analysis.analysisComments[i], "commenter")) {
-                          trail += analysis.analysisComments[i].commenter + " - ";
-                        }
-                        trail += common.formatTimestamp(analysis.analysisComments[i].timestamp, true);
-                        trail += "\n";
-                        trail += analysis.analysisComments[i].comment;
-                        trail += "\n\n";
-                      }
-                      this.auditTrail = trail;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(analysis, "analysisState")) {
-                      this.analysisState = analysis.analysisState;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(analysis, "isSuppressed")) {
-                      this.isSuppressed = analysis.isSuppressed;
-                    } else {
-                      this.isSuppressed = false;
-                    }
+                    this.updateAnalysisData(response.data);
                   });
+                },
+                updateAnalysisData: function(analysis) {
+                  if (Object.prototype.hasOwnProperty.call(analysis, "analysisComments")) {
+                    let trail = "";
+                    for (let i = 0; i < analysis.analysisComments.length; i++) {
+                      if (Object.prototype.hasOwnProperty.call(analysis.analysisComments[i], "commenter")) {
+                        trail += analysis.analysisComments[i].commenter + " - ";
+                      }
+                      trail += common.formatTimestamp(analysis.analysisComments[i].timestamp, true);
+                      trail += "\n";
+                      trail += analysis.analysisComments[i].comment;
+                      trail += "\n\n";
+                    }
+                    this.auditTrail = trail;
+                  }
+                  if (Object.prototype.hasOwnProperty.call(analysis, "analysisState")) {
+                    this.analysisState = analysis.analysisState;
+                  }
+                  if (Object.prototype.hasOwnProperty.call(analysis, "isSuppressed")) {
+                    this.isSuppressed = analysis.isSuppressed;
+                  } else {
+                    this.isSuppressed = false;
+                  }
                 },
                 makeAnalysis: function() {
                   this.callRestEndpoint(this.analysisState, null, null);
@@ -243,6 +245,7 @@
                     isSuppressed: isSuppressed
                   }).then((response) => {
                     this.$toastr.s(this.$t('message.updated'));
+                    this.updateAnalysisData(response.data);
                   }).catch((error) => {
                     this.$toastr.w(this.$t('condition.unsuccessful_action'));
                   });


### PR DESCRIPTION
This PR addresses an issue where the audit trail would not reload after performing analysis actions. Because the analysis data is returned for PUT operations as well, there's no additional overhead.

Before:

![before](https://user-images.githubusercontent.com/5693141/85879576-e91d8180-b7da-11ea-86fa-3a2e776f26b2.gif)

After:

![after](https://user-images.githubusercontent.com/5693141/85879596-ede23580-b7da-11ea-98a4-d22ab773232d.gif)
