### PR TITLE
Make oidc scopes configurable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,10 +23,14 @@ FROM nginx:stable-alpine
 
 # jq is required for entrypoint script
 RUN apk --no-cache add jq
- 
+
 COPY ./docker/etc/nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=build /app/dist /app
+
+# Set default settings that may get overridden to empty values by
+# the entrypoint script, if not explicitly provided by the user
+ENV OIDC_SCOPE "openid profile email"
 
 # Setup entrypoint
 WORKDIR /app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "API_BASE_URL=http://localhost:8081"
       # - "OIDC_ISSUER="
       # - "OIDC_CLIENT_ID="
+      # - "OIDC_SCOPE="
       # - "OIDC_FLOW="
     # volumes:
       # - "/host/path/to/config.json:/app/static/config.json"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,10 +10,12 @@ else
     jq  --arg apiBaseUrl        "$API_BASE_URL" \
         --arg oidcIssuer        "$OIDC_ISSUER" \
         --arg oidcClientId      "$OIDC_CLIENT_ID" \
+        --arg oidcScope         "$OIDC_SCOPE" \
         --arg oidcFlow          "$OIDC_FLOW" \
         '.API_BASE_URL          = $apiBaseUrl 
             | .OIDC_ISSUER      = $oidcIssuer 
-            | .OIDC_CLIENT_ID   = $oidcClientId 
+            | .OIDC_CLIENT_ID   = $oidcClientId
+            | .OIDC_SCOPE       = $oidcScope 
             | .OIDC_FLOW        = $oidcFlow' \
         ./static/config.json > /tmp/config.json
 

--- a/public/static/config.json
+++ b/public/static/config.json
@@ -2,5 +2,6 @@
   "API_BASE_URL": "",
   "OIDC_ISSUER": "",
   "OIDC_CLIENT_ID": "",
+  "OIDC_SCOPE": "openid email profile",
   "OIDC_FLOW": "code"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ axios.get("static/config.json").then(response => {
   // OpenID Connect
   Vue.prototype.$oidc.ISSUER = response.data.OIDC_ISSUER;
   Vue.prototype.$oidc.CLIENT_ID = response.data.OIDC_CLIENT_ID;
+  Vue.prototype.$oidc.SCOPE = response.data.OIDC_SCOPE;
   Vue.prototype.$oidc.FLOW = response.data.OIDC_FLOW;
   createVueApp();
 }).catch(function (error) {

--- a/src/shared/oidc.json
+++ b/src/shared/oidc.json
@@ -1,5 +1,6 @@
 {
     "ISSUER": "",
     "CLIENT_ID": "",
+    "SCOPE": "",
     "FLOW": ""
 }

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -96,8 +96,8 @@ export default {
         authority: this.$oidc.ISSUER,
         client_id: this.$oidc.CLIENT_ID,
         redirect_uri: window.location.origin + "/static/oidc-callback.html",
-        response_type: this.$oidc.FLOW === "implicit" ? "token id_token" : "code",
-        scope: "openid profile email",
+        response_type: this.$oidc.FLOW === "implicit" ? "token" : "code",
+        scope: this.$oidc.SCOPE,
         loadUserInfo: false
       })
     };

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -96,7 +96,7 @@ export default {
         authority: this.$oidc.ISSUER,
         client_id: this.$oidc.CLIENT_ID,
         redirect_uri: window.location.origin + "/static/oidc-callback.html",
-        response_type: this.$oidc.FLOW === "implicit" ? "token" : "code",
+        response_type: this.$oidc.FLOW === "implicit" ? "token id_token" : "code",
         scope: this.$oidc.SCOPE,
         loadUserInfo: false
       })
@@ -157,7 +157,8 @@ export default {
           }
           var oidcAvailableInFrontend =
             this.oidcUserManager.settings.authority &&
-            this.oidcUserManager.settings.client_id;
+            this.oidcUserManager.settings.client_id &&
+            this.oidcUserManager.settings.scope;
           return oidcAvailableInBackend && oidcAvailableInFrontend;
         })
         .catch(err => {


### PR DESCRIPTION
Some providers require OIDC clients to request more than the default scopes. Auth0 for example has extra scopes for `groups`, `roles` and `permissions`: https://auth0.com/docs/extensions/authorization-extension/use-rules-with-the-authorization-extension