### PR TITLE
redirect to original location upon successful login

### DIFF
--- a/public/static/oidc-callback.html
+++ b/public/static/oidc-callback.html
@@ -8,6 +8,31 @@
     <script src="js/axios.min.js"></script>
     <script src="js/oidc-client.min.js"></script>
     <script>
+        const acceptableRootContextPaths = [
+            '/dashboard', '/projects', '/components', '/vulnerabilities', '/licenses', '/policy', '/admin',
+            '/project', '/component', '/vulnerability', '/license', '/login', '/change-password'
+        ];
+        function getContextPath() {
+          if (window.location.pathname === '/static/oidc-callback.html') {
+            // App is deployed in the root context. Return an empty string.
+            return "";
+          } else {
+            // App is deployed in a non-root context. Return the context.
+            return window.location.pathname.substring(0, window.location.pathname.indexOf("/",2));
+          }
+        }
+        function isUrlSaveForRedirect(redirectUrl) {
+          const contextRoot = getContextPath();
+          try {
+            const resultingUrl = new URL(redirectUrl, window.location.origin);
+            return resultingUrl.origin === window.location.origin 
+                    && /^https?:$/.test(resultingUrl.protocol) 
+                    && acceptableRootContextPaths.map(r => contextRoot + r).some(p => redirectUrl.startsWith(p));
+          } catch(invalidUrl) {
+            return false;
+          }
+        }
+
         axios.get("/static/config.json")
             .then((response) => {
                 let config = response.data;
@@ -19,16 +44,13 @@
                 });
             })
             .then((oidcUserManager) => {
-                let redirectTo = (new URLSearchParams(window.location.search)).get("redirect");
-                if (!redirectTo || !redirectTo.startsWith('/')) {
-                    redirectTo = "../";
-                }
+                const redirectTo = (new URLSearchParams(window.location.search)).get("redirect");
 
                 oidcUserManager.getUser()
                     .then((user) => {
                         if (user !== null) {
                             // Implicit flow: Token is already present in URL
-                            window.location.href = redirectTo;
+                            window.location.href = redirectTo && isUrlSaveForRedirect(redirectTo) ? redirectTo : "../";
                             return Promise.resolve()
                         } else {
                             // Code flow: Token must be acquired in exchange for auth code
@@ -36,7 +58,7 @@
                         }
                     })
                     .then((user) => {
-                        window.location.href = redirectTo;
+                        window.location.href = redirectTo && isUrlSaveForRedirect(redirectTo) ? redirectTo : "../";
                     })
                     .catch((err) => {
                         console.log(err);

--- a/public/static/oidc-callback.html
+++ b/public/static/oidc-callback.html
@@ -19,11 +19,16 @@
                 });
             })
             .then((oidcUserManager) => {
+                let redirectTo = (new URLSearchParams(window.location.search)).get("redirect");
+                if (!redirectTo || !redirectTo.startsWith('/')) {
+                    redirectTo = "../";
+                }
+
                 oidcUserManager.getUser()
                     .then((user) => {
                         if (user !== null) {
                             // Implicit flow: Token is already present in URL
-                            window.location.href = "../";
+                            window.location.href = redirectTo;
                             return Promise.resolve()
                         } else {
                             // Code flow: Token must be acquired in exchange for auth code
@@ -31,7 +36,7 @@
                         }
                     })
                     .then((user) => {
-                        window.location.href = "../";
+                        window.location.href = redirectTo;
                     })
                     .catch((err) => {
                         console.log(err);

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,12 +35,12 @@
       $.ajaxSetup({
         headers: {}
       });
-	  
+
       setJwtForAjax(getToken());
 
       // debug logging of ajax requests/responses
       if (getUrlVar('debug')) {
-        $(document).ajaxComplete((event, xhr, settings) => {
+        $(document).ajaxComplete((event, xhr) => {
           console.debug('jQuery-Status:', xhr.status, 'jQuery-Response', xhr.responseJSON || xhr.responseText);
         });
         // Intercept all HTTP requests

--- a/src/containers/DefaultHeaderProfileDropdown.vue
+++ b/src/containers/DefaultHeaderProfileDropdown.vue
@@ -20,6 +20,7 @@
 
 <script>
   import { HeaderDropdown as AppHeaderDropdown } from '@coreui/vue'
+  import EventBus from '../shared/eventbus';
 
   export default {
     name: 'DefaultHeaderProfileDropdown',
@@ -35,7 +36,7 @@
         localStorage.setItem("sessionInvalidate", Date.now().toLocaleString());
         localStorage.removeItem("sessionInvalidate");
         // Removes the token from session storage and reload
-        sessionStorage.removeItem('token');
+        EventBus.$emit('authenticated', null);
         this.$router.replace({ name: "Login" });
       }
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import { getContextPath } from "../shared/utils"
+import { getToken }  from '../shared/permissions';
+import EventBus from '../shared/eventbus';
 
 // Containers
 const DefaultContainer = () => import('@/containers/DefaultContainer');
@@ -209,15 +211,47 @@ function configRoutes() {
     },
     {
       path: '*',
+      name: '404',
       component: Page404
     }
   ]
 }
 
-export default new Router({
+const router = new Router({
   mode: 'history', // https://router.vuejs.org/api/#mode
   base: getContextPath(),
   linkActiveClass: 'open active',
   scrollBehavior: () => ({ y: 0 }),
   routes: configRoutes()
 });
+
+router.beforeEach((to, from, next) => {
+  const jwt = getToken();
+  const publicRoutes = ['Login', '404'];
+  if (!publicRoutes.includes(to.name)) {
+    const redirectTo = to.fullPath;
+    if (jwt) {
+      // let backend verify the token
+      router.app.axios.get(`${router.app.$api.BASE_URL}/${router.app.$api.URL_USER_SELF}`, {
+        headers: { 'Authorization': `Bearer ${jwt}` }
+      }).then(data => {
+        // allowed to proceed
+        next();
+      }).catch(() => {
+        // token is stale
+        // notify app about this
+        EventBus.$emit('authenticated', null);
+        // redirect to login page
+        next({ name: 'Login', query: { redirect: redirectTo }, replace: true });
+      });
+    } else {
+      // no token at all, redirect to login page
+      next({ name: 'Login', query: { redirect: redirectTo }, replace: true });
+    }
+  } else {
+    // allowed to proceed
+    next();
+  }
+});
+
+export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -234,7 +234,7 @@ router.beforeEach((to, from, next) => {
       // let backend verify the token
       router.app.axios.get(`${router.app.$api.BASE_URL}/${router.app.$api.URL_USER_SELF}`, {
         headers: { 'Authorization': `Bearer ${jwt}` }
-      }).then(data => {
+      }).then(() => {
         // allowed to proceed
         next();
       }).catch(() => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -227,7 +227,7 @@ const router = new Router({
 
 router.beforeEach((to, from, next) => {
   const jwt = getToken();
-  const publicRoutes = ['Login', '404'];
+  const publicRoutes = ['Login', '404', 'PasswordForceChange'];
   if (!publicRoutes.includes(to.name)) {
     const redirectTo = to.fullPath;
     if (jwt) {

--- a/src/views/components/ProfileEditModal.vue
+++ b/src/views/components/ProfileEditModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal id="profileEditModal" size="md" @shown="getSelf" @hide="resetValues" hide-header-close no-stacking :title="$t('message.profile_update')">
+  <b-modal id="profileEditModal" size="md" @show="getSelf" @hidden="resetValues" hide-header-close no-stacking :title="$t('message.profile_update')">
 
     <b-input-group-form-input id="fullname-input" input-group-size="mb-3" type="text" v-model="fullname"
                               lazy="true" required="true" feedback="true" autofocus="false"

--- a/src/views/components/ProfileEditModal.vue
+++ b/src/views/components/ProfileEditModal.vue
@@ -27,9 +27,9 @@
     },
     data: () => {
       return {
-        username: String,
-        fullname: String,
-        email: String
+        username: null,
+        fullname: null,
+        email: null
       }
     },
     methods: {

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -75,6 +75,7 @@ import { ValidationObserver } from "vee-validate";
 import BValidatedInputGroupFormInput from "../../forms/BValidatedInputGroupFormInput";
 import InformationalModal from "../modals/InformationalModal";
 import EventBus from '../../shared/eventbus';
+import { getRedirectUrl } from '../../shared/utils';
 const qs = require("querystring");
 
 export default {
@@ -86,8 +87,8 @@ export default {
   },
   data() {
     let redirectUri = `${ window.location.origin }/static/oidc-callback.html`;
-    // redirect to url from query param but only if it starts with / so we do not redirect to external sites
-    const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+    // redirect to url from query param but only if it is save for redirection
+    const redirectTo = getRedirectUrl(this.$router);
     if (redirectTo) {
       redirectUri += `?redirect=${ encodeURIComponent(redirectTo) }`;
     }
@@ -122,8 +123,8 @@ export default {
           "Content-Type": "application/x-www-form-urlencoded"
         }
       };
-      // redirect to url from query param but only if it starts with / so we do not redirect to external sites
-      const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+      // redirect to url from query param but only if it is save for redirection
+      const redirectTo = getRedirectUrl(this.$router);
       axios
         .post(url, qs.stringify(requestBody), config)
         .then(result => {
@@ -204,8 +205,8 @@ export default {
             .then(result => {
               if (result.status === 200) {
                 EventBus.$emit('authenticated', result.data);
-                // redirect to url from query param but only if it starts with / so we do not redirect to external sites
-                const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+                // redirect to url from query param but only if it is save for redirection
+                const redirectTo = getRedirectUrl(this.$router);
                 redirectTo ? this.$router.replace(redirectTo) : this.$router.replace({ name: "Dashboard" });
               }
             })

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -74,6 +74,7 @@ import $ from "jquery";
 import { ValidationObserver } from "vee-validate";
 import BValidatedInputGroupFormInput from "../../forms/BValidatedInputGroupFormInput";
 import InformationalModal from "../modals/InformationalModal";
+import EventBus from '../../shared/eventbus';
 const qs = require("querystring");
 
 export default {
@@ -118,17 +119,10 @@ export default {
         .post(url, qs.stringify(requestBody), config)
         .then(result => {
           if (result.status === 200) {
-            sessionStorage.setItem("token", result.data); // store the JWT in session storage
-            // Set authorization headers for axios and jQuery
-            axios.defaults.headers.common[
-              "Authorization"
-            ] = `Bearer ${result.data}`;
-            $.ajaxSetup({
-              beforeSend: function(xhr) {
-                xhr.setRequestHeader("Authorization", `Bearer ${result.data}`);
-              }
-            });
-            this.$router.replace({ name: "Dashboard" });
+            EventBus.$emit('authenticated', result.data);
+            // redirect to url from query param but only if it starts with / so we do not redirect to external sites
+            const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+            redirectTo ? this.$router.replace(redirectTo) : this.$router.replace({ name: "Dashboard" });
           }
         })
         .catch(err => {
@@ -202,19 +196,10 @@ export default {
             .post(url, qs.stringify(requestBody), config)
             .then(result => {
               if (result.status === 200) {
-                sessionStorage.setItem("token", result.data);
-                axios.defaults.headers.common[
-                  "Authorization"
-                ] = `Bearer ${result.data}`;
-                $.ajaxSetup({
-                  beforeSend: function(xhr) {
-                    xhr.setRequestHeader(
-                      "Authorization",
-                      `Bearer ${result.data}`
-                    );
-                  }
-                });
-                this.$router.replace({ name: "Dashboard" });
+                EventBus.$emit('authenticated', result.data);
+                // redirect to url from query param but only if it starts with / so we do not redirect to external sites
+                const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+                redirectTo ? this.$router.replace(redirectTo) : this.$router.replace({ name: "Dashboard" });
               }
             })
             .catch(err => {

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -85,7 +85,7 @@ export default {
     ValidationObserver
   },
   data() {
-    let redirectUri = `${ window.location.origin } /static/oidc-callback.html`;
+    let redirectUri = `${ window.location.origin }/static/oidc-callback.html`;
     // redirect to url from query param but only if it starts with / so we do not redirect to external sites
     const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
     if (redirectTo) {

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -115,20 +115,20 @@ export default {
           "Content-Type": "application/x-www-form-urlencoded"
         }
       };
+      // redirect to url from query param but only if it starts with / so we do not redirect to external sites
+      const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
       axios
         .post(url, qs.stringify(requestBody), config)
         .then(result => {
           if (result.status === 200) {
             EventBus.$emit('authenticated', result.data);
-            // redirect to url from query param but only if it starts with / so we do not redirect to external sites
-            const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
             redirectTo ? this.$router.replace(redirectTo) : this.$router.replace({ name: "Dashboard" });
           }
         })
         .catch(err => {
           if (err.response.status === 401) {
             if (err.response.data === this.$api.FORCE_PASSWORD_CHANGE) {
-              this.$router.replace({ name: "PasswordForceChange" });
+              this.$router.replace({ name: "PasswordForceChange", query: { redirect: redirectTo } });
               return;
             }
             this.$bvModal.show("modal-informational");

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -85,6 +85,13 @@ export default {
     ValidationObserver
   },
   data() {
+    let redirectUri = `${ window.location.origin } /static/oidc-callback.html`;
+    // redirect to url from query param but only if it starts with / so we do not redirect to external sites
+    const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+    if (redirectTo) {
+      redirectUri += `?redirect=${ encodeURIComponent(redirectTo) }`;
+    }
+
     return {
       loginError: "",
       input: {
@@ -96,7 +103,7 @@ export default {
         userStore: new Oidc.WebStorageStateStore(),
         authority: this.$oidc.ISSUER,
         client_id: this.$oidc.CLIENT_ID,
-        redirect_uri: window.location.origin + "/static/oidc-callback.html",
+        redirect_uri: redirectUri,
         response_type: this.$oidc.FLOW === "implicit" ? "token id_token" : "code",
         scope: this.$oidc.SCOPE,
         loadUserInfo: false

--- a/src/views/pages/Page404.vue
+++ b/src/views/pages/Page404.vue
@@ -8,7 +8,7 @@
             <h4 class="pt-3">{{ $t('404.heading') }}</h4>
             <p class="text-muted">{{ $t('404.message') }}</p>
           </div>
-          <b-button block variant="outline-primary" href="/">{{ $t('404.action') }}</b-button>
+          <b-button block variant="outline-primary" @click="$router.back()">{{ $t('404.action') }}</b-button>
         </b-col>
       </b-row>
     </div>

--- a/src/views/pages/PasswordForceChange.vue
+++ b/src/views/pages/PasswordForceChange.vue
@@ -79,6 +79,7 @@
   import { ValidationObserver } from 'vee-validate';
   import InformationalModal from '../modals/InformationalModal'
   import BValidatedInputGroupFormInput from '../../forms/BValidatedInputGroupFormInput';
+  import { getRedirectUrl } from '../../shared/utils';
   const qs = require('querystring');
 
   export default {
@@ -119,7 +120,7 @@
               this.$toastr.s(this.$t('message.password_change_success'));
               // We don't get the JWT token on a successful password change,
               // reroute users back to login
-              const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+              const redirectTo = getRedirectUrl(this.$router);
               this.$router.replace({ name: "Login", query: { redirect: redirectTo } });
             }
           })

--- a/src/views/pages/PasswordForceChange.vue
+++ b/src/views/pages/PasswordForceChange.vue
@@ -119,7 +119,8 @@
               this.$toastr.s(this.$t('message.password_change_success'));
               // We don't get the JWT token on a successful password change,
               // reroute users back to login
-              this.$router.replace({ name: "Login" });
+              const redirectTo = this.$router.currentRoute.query.redirect && this.$router.currentRoute.query.redirect.startsWith('/') ? this.$router.currentRoute.query.redirect : undefined;
+              this.$router.replace({ name: "Login", query: { redirect: redirectTo } });
             }
           })
           .catch((err) => {

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -78,12 +78,6 @@
             formatter(value, row, index) {
               let url = xssFilters.uriInUnQuotedAttr("../projects/" + row.uuid);
               return `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
-            },
-            events: {
-              'click a': (e,value,row) => {
-                e.preventDefault();
-                this.$router.push({ name: "Project", params: { uuid: row.uuid }})
-              }            
             }
           },
           {


### PR DESCRIPTION
- stores the location before the user is redirected to the login page in the query param "redirect". after successful login, the user gets redirected to this url if it is set. navigation flow will be as follows:
1. http://localhost:8081/projects/285384c9-a18f-465f-921b-d465efd9c43e
2. http://localhost:8081/login?redirect=%2Fprojects%2F285384c9-a18f-465f-921b-d465efd9c43e
3. http://localhost:8081/projects/285384c9-a18f-465f-921b-d465efd9c43e

- uses global navigation guard to ensure the jwt is valid and redirects to login if it is not.
previous implementation checked the jwt only when the app was created. if it was expired afterwards, the app did not recognized that. the guard will take care of this now.

- some other small fixes:
  - "go back" on 404-page always directed the user to "/" --> goes back now as the text implies
  - modal dialog to edit user profile starts fetching the user from the back-end before it already visible. minimizes the effect that the input fields are initially empty and will be filled with content after the dialog is already visible.
  - wrong types for data values in `ProfileEditModal`

references #20 