### PR TITLE
Minor UX improvements

### DIFF
--- a/src/containers/DefaultHeaderProfileDropdown.vue
+++ b/src/containers/DefaultHeaderProfileDropdown.vue
@@ -10,9 +10,9 @@
         class="text-center">
         <strong>{{ $t('message.profile') }}</strong>
       </b-dropdown-header>
-      <b-dropdown-item v-b-modal.profileEditModal><i class="fa fa-user text-primary" /> {{ $t('message.profile_update') }}</b-dropdown-item>
-      <b-dropdown-item to="/change-password"><i class="fa fa-key text-primary" /> {{ $t('message.change_password') }}</b-dropdown-item>
-      <b-dropdown-divider />
+      <b-dropdown-item v-if="canUpdateProfile()" v-b-modal.profileEditModal><i class="fa fa-user text-primary" /> {{ $t('message.profile_update') }}</b-dropdown-item>
+      <b-dropdown-item v-if="canChangePassword()" to="/change-password"><i class="fa fa-key text-primary" /> {{ $t('message.change_password') }}</b-dropdown-item>
+      <b-dropdown-divider v-if="canUpdateProfile() || canChangePassword()" />
       <b-dropdown-item @click="logout"><i class="fa fa-sign-out text-primary" /> {{ $t('message.logout') }}</b-dropdown-item>
     </template>
   </AppHeaderDropdown>
@@ -21,6 +21,7 @@
 <script>
   import { HeaderDropdown as AppHeaderDropdown } from '@coreui/vue'
   import EventBus from '../shared/eventbus';
+  import { decodeToken, getToken } from '../shared/permissions'
 
   export default {
     name: 'DefaultHeaderProfileDropdown',
@@ -28,7 +29,10 @@
       AppHeaderDropdown
     },
     data: () => {
-      return { itemsCount: 42 }
+      return { 
+        itemsCount: 42,
+        identityProvider: decodeToken(getToken()).idp
+      }
     },
     methods: {
       logout: function () {
@@ -38,6 +42,12 @@
         // Removes the token from session storage and reload
         EventBus.$emit('authenticated', null);
         this.$router.replace({ name: "Login" });
+      },
+      canChangePassword: function() {
+        return this.identityProvider == "LOCAL";
+      },
+      canUpdateProfile: function() {
+        return this.identityProvider == "LOCAL";
       }
     }
   }

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -147,7 +147,16 @@ export default {
           }
         });
     },
+    isOidcAvailableInFrontend() {
+      return this.oidcUserManager.settings.authority &&
+        this.oidcUserManager.settings.client_id &&
+        this.oidcUserManager.settings.scope
+    },
     checkOidcAvailability() {
+      if (!this.isOidcAvailableInFrontend()) {
+        return Promise.resolve(false);
+      }
+
       const url = this.$api.BASE_URL + "/" + this.$api.URL_OIDC_AVAILABLE;
 
       return axios
@@ -157,11 +166,7 @@ export default {
           if (result.status === 200) {
             oidcAvailableInBackend = result.data === true;
           }
-          var oidcAvailableInFrontend =
-            this.oidcUserManager.settings.authority &&
-            this.oidcUserManager.settings.client_id &&
-            this.oidcUserManager.settings.scope;
-          return oidcAvailableInBackend && oidcAvailableInFrontend;
+          return oidcAvailableInBackend;
         })
         .catch(err => {
           return Promise.reject(err);


### PR DESCRIPTION
* Don't show *Update Profile* and *Change Password* options in profile dropdown when authentication was performed with LDAP or OIDC. Until now, the frontend suggested that these actions were possible, when in fact they arent
* Don't try to check OIDC availability in the API server when OIDC wasn't configured in the frontend. This mainly resolves some confusion some folks had, where they'd see OIDC related error-toasts without having it configured