### PR TITLE
Remove email from OidcUsers columns

### DIFF
--- a/src/views/administration/accessmanagement/OidcUsers.vue
+++ b/src/views/administration/accessmanagement/OidcUsers.vue
@@ -70,14 +70,6 @@
             }
           },
           {
-            title: this.$t('message.email'),
-            field: "email",
-            sortable: false,
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
-            }
-          },
-          {
             title: this.$t('admin.teams'),
             field: "teams",
             sortable: false,


### PR DESCRIPTION
E-Mail is not persisted for `OidcUser`s and is only available in each user's session. See https://github.com/stevespringett/Alpine/blob/alpine-parent-1.9.0/alpine/src/main/java/alpine/model/OidcUser.java#L53. This column will be empty 100% of the time, which may cause confusion.