### PR TITLE
Adds language specific analysis state values in tables

### DIFF
--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -118,6 +118,30 @@ $common.formatAnalyzerLabel = function formatAnalyzerLabel(analyzer, vulnId, alt
 };
 
 /**
+ * 
+ * @param {*} i18n - VueI18n instance with $t translate function available
+ * @returns a specialized label for an analysis state (NOT_SET, APPROVED, REJECTED, etc). 
+ * It must have a corresponding entry in the locales files (e.g. src/locales/en.json) 
+ * (not_set, approved, rejected, etc.)
+ */
+$common.makeAnalysisStateLabelFormatter = (i18n) => {
+  return function (value) {
+    switch (value) {
+      case 'NOT_SET':
+      case 'APPROVED':
+      case 'REJECTED':
+      case 'EXPLOITABLE':
+      case 'IN_TRIAGE':
+      case 'FALSE_POSITIVE':
+      case 'NOT_AFFECTED':
+        return i18n.$t(`message.${value.toLowerCase()}`)
+      default:
+        return null;
+    }
+  }
+};
+
+/**
  * Given a UNIX timestamp, this function will return a formatted date.
  * i.e. 15 Jan 2017
  */
@@ -216,6 +240,7 @@ module.exports = {
   formatViolationStateLabel: $common.formatViolationStateLabel,
   formatCweLabel: $common.formatCweLabel,
   formatAnalyzerLabel: $common.formatAnalyzerLabel,
+  makeAnalysisStateLabelFormatter: $common.makeAnalysisStateLabelFormatter,
   formatTimestamp: $common.formatTimestamp,
   concatenateComponentName: $common.concatenateComponentName,
   valueWithDefault: $common.valueWithDefault,

--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -73,9 +73,7 @@
             sortable: false,
             class: "tight",
             visible: false,
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
-            }
+            formatter: common.makeAnalysisStateLabelFormatter(this),
           },
           {
             title: this.$t('message.suppressed'),

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -24,7 +24,7 @@
   import bootstrapTableMixin from "../../../mixins/bootstrapTableMixin";
   import xssFilters from "xss-filters";
   import i18n from "../../../i18n";
-  import BootstrapToggle from 'vue-bootstrap-toggle'
+  import BootstrapToggle from 'vue-bootstrap-toggle';
 
   export default {
     props: {
@@ -121,9 +121,7 @@
             title: this.$t('message.analysis'),
             field: "analysis.state",
             sortable: true,
-            formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
-            }
+            formatter: common.makeAnalysisStateLabelFormatter(this),
           },
           {
             title: this.$t('message.suppressed'),

--- a/src/views/portfolio/projects/ProjectPolicyViolations.vue
+++ b/src/views/portfolio/projects/ProjectPolicyViolations.vue
@@ -97,9 +97,7 @@ export default {
           title: this.$t('message.analysis'),
           field: "analysis.analysisState",
           sortable: false,
-          formatter(value, row, index) {
-            return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
-          }
+          formatter: common.makeAnalysisStateLabelFormatter(this),
         },
         {
           title: this.$t('message.suppressed'),


### PR DESCRIPTION
# Summary
Resolves https://github.com/DependencyTrack/dependency-track/issues/946 
As this is my first issue for DependencyTrack, please let me know if I need to make any changes or you would like to see anything done differently. 

# Updates
- Adds makeAnalysisStateLabelFormatter to common utilities to translate analysis states to human readable names.
- Updates 3 components to use the analysis state label formatter:
  - [ComponentVulnerabilities.vue#L77](https://github.com/DependencyTrack/frontend/blob/master/src/views/portfolio/projects/ComponentVulnerabilities.vue#L77)
  - [ProjectPolicyViolations.vue#L101](https://github.com/DependencyTrack/frontend/blob/master/src/views/portfolio/projects/ProjectPolicyViolations.vue#L101)
  - [ProjectFindings.vue#L125](https://github.com/DependencyTrack/frontend/blob/master/src/views/portfolio/projects/ProjectFindings.vue#L125)
  
# Screenshots

Before:

![analysis-state-before](https://user-images.githubusercontent.com/2287187/112082575-014ce200-8b5c-11eb-8ff9-81f27240c6b0.PNG)

After:

![analysis-state-after](https://user-images.githubusercontent.com/2287187/112082573-00b44b80-8b5c-11eb-95d7-bb09002756f7.PNG)



