### PR TITLE
Update Dockerfile for OpenShift

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,12 @@ COPY ./docker/etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 
 COPY --chown=101:101 ./dist /app
 
+# Applying these changes allows the container to run via the OpenShift default SCC "Restricted" whereby arbitrary an UID and GID=0 are assigned
+RUN chgrp -R 0 /etc/nginx && \
+    chmod -R g=u /etc/nginx && \
+    chgrp -R 0 /app && \
+    chmod -R g=u /app
+
 # Specify the user to run as (in numeric format for compatibility with Kubernetes/OpenShift's SCC)
 # Inherited from parent image
 # See https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile#L139


### PR DESCRIPTION
Hi, I am running Dependency Track 4.2.1 on OpenShift. OpenShift applies its Restricted SCC to deployments by default, whereby it assigns an arbitrary UID to the container and also assigns it GID=0. Therefore if we update Dockerfiles to chown/chgrp GID=0 and also chmod g=u (so that the group 0 has same permissions as user) we can ensure the Dockerfiles are compatible with OpenShift best practice.

Reference: "Support arbitrary user ids" https://docs.openshift.com/container-platform/4.1/openshift_images/create-images.html