### PR TITLE
Fix #79 and add option for OIDC login button text

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       # - "OIDC_CLIENT_ID="
       # - "OIDC_SCOPE="
       # - "OIDC_FLOW="
+      # - "OIDC_LOGIN_BUTTON_TEXT="
     # volumes:
       # - "/host/path/to/config.json:/app/static/config.json"
     ports:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,16 +7,18 @@ if mount | grep '/static/config.json'; then
     echo "config.json is mounted from host - ENV configuration will be ignored"
 else
     # Apply ENV vars to temporary config.json
-    jq  --arg apiBaseUrl        "$API_BASE_URL" \
-        --arg oidcIssuer        "$OIDC_ISSUER" \
-        --arg oidcClientId      "$OIDC_CLIENT_ID" \
-        --arg oidcScope         "$OIDC_SCOPE" \
-        --arg oidcFlow          "$OIDC_FLOW" \
-        '.API_BASE_URL          = $apiBaseUrl 
-            | .OIDC_ISSUER      = $oidcIssuer 
-            | .OIDC_CLIENT_ID   = $oidcClientId
-            | .OIDC_SCOPE       = $oidcScope 
-            | .OIDC_FLOW        = $oidcFlow' \
+    jq  --arg apiBaseUrl          "$API_BASE_URL" \
+        --arg oidcIssuer          "$OIDC_ISSUER" \
+        --arg oidcClientId        "$OIDC_CLIENT_ID" \
+        --arg oidcScope           "$OIDC_SCOPE" \
+        --arg oidcFlow            "$OIDC_FLOW" \
+        --arg oidcLoginButtonText "$OIDC_LOGIN_BUTTON_TEXT" \
+        '.API_BASE_URL                = $apiBaseUrl 
+            | .OIDC_ISSUER            = $oidcIssuer 
+            | .OIDC_CLIENT_ID         = $oidcClientId 
+            | .OIDC_SCOPE             = $oidcScope 
+            | .OIDC_FLOW              = $oidcFlow 
+            | .OIDC_LOGIN_BUTTON_TEXT = $oidcLoginButtonText' \
         ./static/config.json > /tmp/config.json
 
     # Override default config file

--- a/public/static/config.json
+++ b/public/static/config.json
@@ -3,5 +3,6 @@
   "OIDC_ISSUER": "",
   "OIDC_CLIENT_ID": "",
   "OIDC_SCOPE": "openid email profile",
-  "OIDC_FLOW": "code"
+  "OIDC_FLOW": "code",
+  "OIDC_LOGIN_BUTTON_TEXT" : ""
 }

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,11 @@ axios.get(contextPath + "/static/config.json").then(response => {
   Vue.prototype.$oidc.CLIENT_ID = response.data.OIDC_CLIENT_ID;
   Vue.prototype.$oidc.SCOPE = response.data.OIDC_SCOPE;
   Vue.prototype.$oidc.FLOW = response.data.OIDC_FLOW;
+  if (response.data.OIDC_LOGIN_BUTTON_TEXT) {
+    Vue.prototype.$oidc.LOGIN_BUTTON_TEXT = response.data.OIDC_LOGIN_BUTTON_TEXT;
+  } else {
+    Vue.prototype.$oidc.LOGIN_BUTTON_TEXT = "";
+  }
   createVueApp();
 }).catch(function (error) {
   console.log("Cannot retrieve static/config.json from host. This is expected behavior in development environments.");

--- a/src/shared/oidc.json
+++ b/src/shared/oidc.json
@@ -2,5 +2,6 @@
     "ISSUER": "",
     "CLIENT_ID": "",
     "SCOPE": "",
-    "FLOW": ""
+    "FLOW": "",
+    "LOGIN_BUTTON_TEXT": ""
 }

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -43,7 +43,8 @@
                       </b-col>
                       <b-col cols="6" v-show="oidcAvailable">
                         <b-button style="float: right" v-on:click="oidcLogin()">
-                          <img alt="OpenID Logo" src="@/assets/img/openid-logo.svg" width="60px" />
+                          <span v-if="oidcCheckLoginButtonTextSetted()">{{ oidcLoginButtonText() }}</span>
+                          <img alt="OpenID Logo" src="@/assets/img/openid-logo.svg" width="60px" v-else />
                         </b-button>
                       </b-col>
                     </b-row>
@@ -177,6 +178,12 @@ export default {
         console.log(err);
         this.$toastr.e(this.$t("message.oidc_redirect_failed"));
       });
+    },
+    oidcCheckLoginButtonTextSetted() {
+        return this.$oidc.LOGIN_BUTTON_TEXT.length > 0;
+    },
+    oidcLoginButtonText() {
+        return this.$oidc.LOGIN_BUTTON_TEXT;
     }
   },
   mounted() {


### PR DESCRIPTION
This PR fixes issue #79. Now it is possible to set env variable `OIDC_LOGIN_BUTTON_TEXT` and it's value will be shown as OIDC login button text.