### PR TITLE
Update CWE Link to use HTTPS

### DIFF
--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -146,7 +146,7 @@
       },
       cweLink () {
         if (this.vulnerability.cwe) {
-          return `http://cwe.mitre.org/data/definitions/${this.vulnerability.cwe.cweId}`;
+          return `https://cwe.mitre.org/data/definitions/${this.vulnerability.cwe.cweId}`;
         } else {
           return null;
         }


### PR DESCRIPTION
Tweak the URL used in cweLink to use HTTPS instead of HTTP.

Whilst modern browsers do now automatically redirect HTTP to HTTPS, it's better that the secure protocol be used by default so as to "practice what we preach". 