### PR TITLE
show classifier in project list

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -89,6 +89,11 @@
             }
           },
           {
+            title: this.$t('message.classifier'),
+            field: "classifier",
+            sortable: true
+          },
+          {
             title: this.$t('message.last_bom_import'),
             field: "lastBomImport",
             sortable: true,

--- a/src/views/portfolio/projects/ProjectUploadBomModal.vue
+++ b/src/views/portfolio/projects/ProjectUploadBomModal.vue
@@ -6,7 +6,7 @@
     <template v-slot:modal-footer="{ cancel }">
       <b-button size="md" variant="secondary" @click="cancel()">{{ $t('message.cancel') }}</b-button>
       <b-button size="md" variant="secondary" @click="file = null">{{ $t('message.reset') }}</b-button>
-      <b-button size="md" variant="primary" @click="upload()">{{ $t('message.upload') }}</b-button>
+      <b-button size="md" variant="primary" @click="upload()" :disabled="file === null">{{ $t('message.upload') }}</b-button>
     </template>
   </b-modal>
 </template>

--- a/src/views/portfolio/projects/ProjectUploadBomModal.vue
+++ b/src/views/portfolio/projects/ProjectUploadBomModal.vue
@@ -6,7 +6,7 @@
     <template v-slot:modal-footer="{ cancel }">
       <b-button size="md" variant="secondary" @click="cancel()">{{ $t('message.cancel') }}</b-button>
       <b-button size="md" variant="secondary" @click="file = null">{{ $t('message.reset') }}</b-button>
-      <b-button size="md" variant="primary" @click="upload()" :disabled="file === null">{{ $t('message.upload') }}</b-button>
+      <b-button size="md" variant="primary" @click="upload()">{{ $t('message.upload') }}</b-button>
     </template>
   </b-modal>
 </template>


### PR DESCRIPTION
Show classifier in project list to improve overview of heterogeneous projects. 
When monitoring different kind of projects(docker images, libraries etc. ), it is helpful to see the classifier in project list.