### PR TITLE
Reduce hit radius of graphs to avoid #92

### DIFF
--- a/src/views/dashboard/ChartAuditingProgress.vue
+++ b/src/views/dashboard/ChartAuditingProgress.vue
@@ -88,7 +88,7 @@
             },
             point: {
               radius: 0,
-              hitRadius: 100,
+              hitRadius: 20,
               hoverRadius: 4,
               hoverBorderWidth: 3
             }

--- a/src/views/dashboard/ChartComponentVulnerabilities.vue
+++ b/src/views/dashboard/ChartComponentVulnerabilities.vue
@@ -88,7 +88,7 @@
             },
             point: {
               radius: 0,
-              hitRadius: 100,
+              hitRadius: 20,
               hoverRadius: 4,
               hoverBorderWidth: 3
             }

--- a/src/views/dashboard/ChartPolicyViolations.vue
+++ b/src/views/dashboard/ChartPolicyViolations.vue
@@ -99,7 +99,7 @@ export default {
           },
           point: {
             radius: 0,
-            hitRadius: 100,
+            hitRadius: 20,
             hoverRadius: 4,
             hoverBorderWidth: 3
           }

--- a/src/views/dashboard/ChartPortfolioVulnerabilities.vue
+++ b/src/views/dashboard/ChartPortfolioVulnerabilities.vue
@@ -121,7 +121,7 @@
             },
             point: {
               radius: 0,
-              hitRadius: 100,
+              hitRadius: 20,
               hoverRadius: 4,
               hoverBorderWidth: 3
             }

--- a/src/views/dashboard/ChartProjectVulnerabilities.vue
+++ b/src/views/dashboard/ChartProjectVulnerabilities.vue
@@ -88,7 +88,7 @@
             },
             point: {
               radius: 0,
-              hitRadius: 100,
+              hitRadius: 20,
               hoverRadius: 4,
               hoverBorderWidth: 3
             }


### PR DESCRIPTION
Should fix #92 or at least make it more usable. It may be a little awkward for users used to the old large hover hitboxes though will avoid the issues as seen in #92.
