### PR TITLE
OIDC: Store redirect URL in `state`

### DIFF
--- a/public/static/oidc-callback.html
+++ b/public/static/oidc-callback.html
@@ -13,24 +13,24 @@
             '/project', '/component', '/vulnerability', '/license', '/login', '/change-password'
         ];
         function getContextPath() {
-          if (window.location.pathname === '/static/oidc-callback.html') {
-            // App is deployed in the root context. Return an empty string.
-            return "";
-          } else {
-            // App is deployed in a non-root context. Return the context.
-            return window.location.pathname.substring(0, window.location.pathname.indexOf("/",2));
-          }
+            if (window.location.pathname === '/static/oidc-callback.html') {
+                // App is deployed in the root context. Return an empty string.
+                return "";
+            } else {
+                // App is deployed in a non-root context. Return the context.
+                return window.location.pathname.substring(0, window.location.pathname.indexOf("/",2));
+            }
         }
         function isUrlSaveForRedirect(redirectUrl) {
-          const contextRoot = getContextPath();
-          try {
-            const resultingUrl = new URL(redirectUrl, window.location.origin);
-            return resultingUrl.origin === window.location.origin
+            const contextRoot = getContextPath();
+            try {
+                const resultingUrl = new URL(redirectUrl, window.location.origin);
+                return resultingUrl.origin === window.location.origin
                     && /^https?:$/.test(resultingUrl.protocol)
                     && acceptableRootContextPaths.map(r => contextRoot + r).some(p => redirectUrl.startsWith(p));
-          } catch(invalidUrl) {
-            return false;
-          }
+            } catch(invalidUrl) {
+                return false;
+            }
         }
 
         axios.get("/static/config.json")
@@ -44,25 +44,11 @@
                 });
             })
             .then((oidcUserManager) => {
-                const redirectTo = (new URLSearchParams(window.location.search)).get("redirect");
-
-                oidcUserManager.getUser()
-                    .then((user) => {
-                        if (user !== null) {
-                            // Implicit flow: Token is already present in URL
-                            window.location.href = redirectTo && isUrlSaveForRedirect(redirectTo) ? redirectTo : "../";
-                            return Promise.resolve()
-                        } else {
-                            // Code flow: Token must be acquired in exchange for auth code
-                            return oidcUserManager.signinRedirectCallback();
-                        }
-                    })
-                    .then((user) => {
-                        window.location.href = redirectTo && isUrlSaveForRedirect(redirectTo) ? redirectTo : "../";
-                    })
-                    .catch((err) => {
-                        console.log(err);
-                    })
+                return oidcUserManager.signinRedirectCallback();
+            })
+            .then((user) => {
+                const redirectTo = user.state;
+                window.location.href = redirectTo && isUrlSaveForRedirect(redirectTo) ? redirectTo : "../";
             })
             .catch((err) => {
                 console.log(err);

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -87,13 +87,6 @@ export default {
     ValidationObserver
   },
   data() {
-    let redirectUri = `${ window.location.origin }/static/oidc-callback.html`;
-    // redirect to url from query param but only if it is save for redirection
-    const redirectTo = getRedirectUrl(this.$router);
-    if (redirectTo) {
-      redirectUri += `?redirect=${ encodeURIComponent(redirectTo) }`;
-    }
-
     return {
       loginError: "",
       input: {
@@ -105,7 +98,7 @@ export default {
         userStore: new Oidc.WebStorageStateStore(),
         authority: this.$oidc.ISSUER,
         client_id: this.$oidc.CLIENT_ID,
-        redirect_uri: redirectUri,
+        redirect_uri: `${ window.location.origin }/static/oidc-callback.html`,
         response_type: this.$oidc.FLOW === "implicit" ? "token id_token" : "code",
         scope: this.$oidc.SCOPE,
         loadUserInfo: false
@@ -174,10 +167,14 @@ export default {
         });
     },
     oidcLogin() {
-      this.oidcUserManager.signinRedirect().catch(err => {
-        console.log(err);
-        this.$toastr.e(this.$t("message.oidc_redirect_failed"));
-      });
+      this.oidcUserManager
+        .signinRedirect({
+          state: getRedirectUrl(this.$router)}
+        )
+        .catch(err => {
+          console.log(err);
+          this.$toastr.e(this.$t("message.oidc_redirect_failed"));
+        });
     },
     oidcCheckLoginButtonTextSetted() {
         return this.$oidc.LOGIN_BUTTON_TEXT.length > 0;


### PR DESCRIPTION
Multiple IdPs disallow usage of custom query parameters in the authorization request's `redirect_uri`. By storing the target URL in `state`, `redirect_uri` can remain static without query params.

Fixes #64, related to https://github.com/DependencyTrack/frontend/pull/47#issuecomment-1024666503

Tested with Auth0 and Keycloak, both for `code` and `implicit` flows. Here's a GIF showing this working with Keycloak:

![oidc-redirect](https://user-images.githubusercontent.com/5693141/151660281-1dad70c0-e2cd-4612-99f2-329576641db6.gif)