### PR TITLE
Fix "Affected Projects" tab in Vulnerability view not being visible to users with `VIEW_VULNERABILITY` permission

### DIFF
--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -95,7 +95,7 @@
         </div>
 
       </b-tab>
-      <b-tab v-if="isPermitted(PERMISSIONS.VULNERABILITY_ANALYSIS)">
+      <b-tab v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.affected_projects') }} <b-badge variant="tab-total">{{ totalAffectedProjects }}</b-badge></template>
         <affected-projects :key="this.uuid" :source="source" :vulnId="vulnId" v-on:total="totalAffectedProjects = $event" />
       </b-tab>


### PR DESCRIPTION
Signed-off-by: nscuro <nscuro@protonmail.com>

Thanks to @msymons for reporting!