### PR TITLE
Show Security Risk in policy violations overview (fixes #91)

### DIFF
--- a/src/views/dashboard/ChartPolicyViolationBreakdown.vue
+++ b/src/views/dashboard/ChartPolicyViolationBreakdown.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-<!-- TODO
     <div class="progress-group">
       <div class="progress-group-header">
         <i class="fa fa-shield fa-fw progress-group-icon"></i>
@@ -11,7 +10,6 @@
         <b-progress height={} class="progress-xs" :value="securityPercent" variant="violation-type"></b-progress>
       </div>
     </div>
--->
     <div class="progress-group">
       <div class="progress-group-header">
         <i class="fa fa-balance-scale fa-fw progress-group-icon"></i>


### PR DESCRIPTION
@stevespringett Do you remember why this was commented out? The code seems to be working just fine:
<img width="1331" alt="Security Risk" src="https://user-images.githubusercontent.com/62144407/166006694-8df63af8-2f85-45a7-b0ee-441306f17885.png">

Fixes #91

