### PR TITLE
Disable source maps for production builds #192

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -3,7 +3,7 @@ const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin');
 
 module.exports = {
   lintOnSave: false,
-  productionSourceMap: false
+  productionSourceMap: false,
   runtimeCompiler: true,
   // Relative paths cannot be supported. Research by @nscur0 - https://owasp.slack.com/archives/CTC03GX9S/p1608400149085400
   publicPath: "/",

--- a/vue.config.js
+++ b/vue.config.js
@@ -3,6 +3,7 @@ const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin');
 
 module.exports = {
   lintOnSave: false,
+  productionSourceMap: false
   runtimeCompiler: true,
   // Relative paths cannot be supported. Research by @nscur0 - https://owasp.slack.com/archives/CTC03GX9S/p1608400149085400
   publicPath: "/",


### PR DESCRIPTION
Configuring the build to not generate source maps in production. Local testing shows it reduces the final Docker image size by 40%.