### PR TITLE
Fixed email configuration tooltip wording

### DIFF
--- a/src/views/administration/configuration/EmailTestConfigurationModal.vue
+++ b/src/views/administration/configuration/EmailTestConfigurationModal.vue
@@ -7,7 +7,7 @@
       rules="required"
       type="email"
       v-model="emailAddress"
-      tooltip="This URL is used to construct links back to Dependency-Track from external systems."
+      tooltip="Enter an email address you control to test your send configuration."
       lazy="true"
     />
     <template v-slot:modal-footer="{ cancel }">


### PR DESCRIPTION
Hover text for email configuration test input box was copypasta. Added appropriate wording.

Reported in #161.