### PR TITLE
Calculate CVSS scores dynamically when only the vector is known

### DIFF
--- a/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
@@ -618,9 +618,15 @@ export default {
         this.cvssv2Vector.c = vector.C;
         this.cvssv2Vector.i = vector.I;
         this.cvssv2Vector.a = vector.A;
-        this.cvssV2Score.baseScore = this.vulnerability.cvssV2BaseScore;
-        this.cvssV2Score.impactSubScore = this.vulnerability.cvssV2ImpactSubScore;
-        this.cvssV2Score.exploitabilitySubScore = this.vulnerability.cvssV2ExploitabilitySubScore;
+        if (this.vulnerability.cvssV2BaseScore
+          && this.vulnerability.cvssV2ImpactSubScore
+          && this.vulnerability.cvssV2ExploitabilitySubScore) {
+          this.cvssV2Score.baseScore = this.vulnerability.cvssV2BaseScore;
+          this.cvssV2Score.impactSubScore = this.vulnerability.cvssV2ImpactSubScore;
+          this.cvssV2Score.exploitabilitySubScore = this.vulnerability.cvssV2ExploitabilitySubScore;
+        } else {
+          this.retrieveCvssScore(this.vulnerability.cvssV2Vector, 2);
+        }
       }
       return vector;
     },
@@ -639,9 +645,15 @@ export default {
         this.cvssv3Vector.c = vector.C;
         this.cvssv3Vector.i = vector.I;
         this.cvssv3Vector.a = vector.A;
-        this.cvssV3Score.baseScore = this.vulnerability.cvssV3BaseScore;
-        this.cvssV3Score.impactSubScore = this.vulnerability.cvssV3ImpactSubScore;
-        this.cvssV3Score.exploitabilitySubScore = this.vulnerability.cvssV3ExploitabilitySubScore;
+        if (this.vulnerability.cvssV3BaseScore
+          && this.vulnerability.cvssV3ImpactSubScore
+          && this.vulnerability.cvssV3ExploitabilitySubScore) {
+          this.cvssV3Score.baseScore = this.vulnerability.cvssV3BaseScore;
+          this.cvssV3Score.impactSubScore = this.vulnerability.cvssV3ImpactSubScore;
+          this.cvssV3Score.exploitabilitySubScore = this.vulnerability.cvssV3ExploitabilitySubScore;
+        } else {
+          this.retrieveCvssScore(this.vulnerability.cvssV3Vector, 3);
+        }
       }
       return vector;
     },


### PR DESCRIPTION
Fixes an issue where the `VulnerabilityDetailsModal` would not render any information at all, if no CVSS scores were returned by the API.

This surfaced for OSV vulnerabilities that on some occasions don't have CVSS scores, despite having CVSS vectors. This can and will be addressed in the OSV mirror task, but the frontend should be able to handle these situations as well.

Before:
![before](https://user-images.githubusercontent.com/5693141/188316086-dc4c4bc0-a338-476c-a293-a4d7f4e6fd68.gif)

After:
![after](https://user-images.githubusercontent.com/5693141/188316107-02a25182-5122-413d-b10e-e11072bd2fe4.gif)

