### PR TITLE
Bump `merge` to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8117,9 +8117,9 @@
       }
     },
     "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w=="
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
     "uuid": "7.0.3",
     "vue-template-compiler": "2.6.14"
   },
+  "overrides": {
+    "vue-bootstrap-toggle": {
+      "merge": "2.1.1"
+    }
+  },
   "browserslist": [
     "> 1%",
     "last 2 versions",


### PR DESCRIPTION
Fixes:
* https://security.snyk.io/vuln/SNYK-JS-MERGE-1040469
* https://security.snyk.io/vuln/SNYK-JS-MERGE-1042987

`vue-bootstrap-toggle` only uses a single function of `merge`. That function still exists in v2 of `merge`, so this version bump is not a breaking change. See https://github.com/rhyek/vue-bootstrap-toggle/blob/16cf66e4346119ea5b72ec2abeafe524b55bbaee/src/index.vue#L51

Further, the vulnerabilities (both prototype pollutions) are not exploitable, as neither of the arguments passed to `merge.recursive` are user-controllable.

Still performing the update to make scanners happy.

Signed-off-by: nscuro <nscuro@protonmail.com>