### PR TITLE
Remove unnecessary hz-scrollbar on expanded rows

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -227,6 +227,7 @@ input.required, select.required, textarea.required {
 .expanded-row {
   margin-top:-12px;
   margin-bottom:-12px;
+  margin-right: -13px;
   padding-top:20px;
   padding-bottom: 20px;
   background-color: $grey-800;


### PR DESCRIPTION
This effectively reduce the width of an `expanded-row` by 2 pixels to remove the scrollbar, when it is not necessary. It turns out that `border-collapse: collapse;` on the table causing the scrollbars to be shown. Because of setting this attribute to `seperate` will change the appearance, i adjusted the margin of the expanded-rows instead. The commit will overwrite the `margin-right: -15px`, which is set by the row class.

Tested on Chrome and Firefox. Please someone test it on Safari.

Fixes #248 