### PR TITLE
Enable release creation from non-master branches

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -36,7 +36,7 @@ jobs:
 
           npm version ${{ github.event.inputs.version-to-bump }} -m "prepare-release: set version to %s"
 
-          git push origin "HEAD:refs/heads/master"
+          git push origin "HEAD:${{ github.ref }}"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
This just makes the destination of version bump commits dependent on the branch the workflow is running on, instead of always pushing to `master`. This will allow us to run the workflow on release branches as well.

Signed-off-by: nscuro <nscuro@protonmail.com>