### PR TITLE
Specify the target branch when creating a release via GitHub CLI

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -50,5 +50,6 @@ jobs:
           fi
 
           gh release create "${VERSION}" ${GH_OPTS} \
+            --target "${{ github.ref_name }}" \
             --title "${VERSION}" \
             --notes-file ".github/default-release-notes.md"


### PR DESCRIPTION
It uses `master` per default, which is not the intention when releasing from a release branch.

Signed-off-by: nscuro <nscuro@protonmail.com>