### PR TITLE
aliases: improve alias column, show aliases optionally in all vulnerability lists 

### DIFF
--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -39,6 +39,24 @@
             }
           },
           {
+            title: this.$t('message.aliases'),
+            field: "aliases",
+            sortable: true,
+            visible: false,
+            formatter(value, row, index) {
+              if (typeof value !== 'undefined') {
+                let label = "";
+                for (let i=0; i<value.length; i++) {
+                  let alias = common.resolveVulnAliasInfo(row.source, value[i]);
+                  let url = xssFilters.uriInUnQuotedAttr("../vulnerabilities/" + alias.source + "/" + alias.vulnId);
+                  label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
+                  if (i < value.length-1) label += "<br/><br/>"
+                }
+                return label;
+              }
+            }
+          },
+          {
             title: this.$t('message.published'),
             field: "published",
             sortable: true,

--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -41,7 +41,6 @@
           {
             title: this.$t('message.aliases'),
             field: "aliases",
-            sortable: true,
             visible: false,
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -140,7 +140,6 @@
           {
             title: this.$t('message.aliases'),
             field: "vulnerability.aliases",
-            sortable: true,
             visible: false,
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -149,7 +149,7 @@
                   let alias = common.resolveVulnAliasInfo(row.vulnerability.source, value[i]);
                   let url = xssFilters.uriInUnQuotedAttr("../../../vulnerabilities/" + alias.source + "/" + alias.vulnId);
                   label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
-                  if (i < value.length-1) label += ", "
+                  if (i < value.length-1) label += "<br/><br/>"
                 }
                 return label;
               }

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -64,7 +64,6 @@
           {
             title: this.$t('message.aliases'),
             field: "aliases",
-            sortable: true,
             visible: false,
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -62,6 +62,24 @@
             }
           },
           {
+            title: this.$t('message.aliases'),
+            field: "aliases",
+            sortable: true,
+            visible: false,
+            formatter(value, row, index) {
+              if (typeof value !== 'undefined') {
+                let label = "";
+                for (let i=0; i<value.length; i++) {
+                  let alias = common.resolveVulnAliasInfo(row.source, value[i]);
+                  let url = xssFilters.uriInUnQuotedAttr("../vulnerabilities/" + alias.source + "/" + alias.vulnId);
+                  label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
+                  if (i < value.length-1) label += "<br/><br/>"
+                }
+                return label;
+              }
+            }
+          },
+          {
             title: this.$t('message.published'),
             field: "published",
             sortable: true,


### PR DESCRIPTION
### Description

2023-02-15 Attempt 2 at this PR: 

The Audit Vulnerabilities tab for a project has an extra column that can be shown to list the aliases of a vulnerability. This PR improves the alignment of these aliases to make it look a little bit better.

Old:

![image](https://user-images.githubusercontent.com/4426050/219104772-06781b14-7cb2-4a51-8e02-0066323a2fe9.png)

New:

![image](https://user-images.githubusercontent.com/4426050/219104882-a9d79f75-192f-4c5c-9431-a183d93e5b91.png)


I have also added this optional column to the global Vulnerabilities and Components lists

### Addressed Issue

- Vulnerabilities with multiple aliases look ugly in Audit Vulnerabilities tab
- Alias column can be useful also in Components list and Vulnerabilities list

### Additional Details

Not everybody might feel this is the "perfect" solution, but let's not [make "perfect" the enemy of "good"](https://en.wikipedia.org/wiki/Perfect_is_the_enemy_of_good) :-)

Not sure if there's a practical way to wrap around each alias without using <br/>

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly





Signed-off-by: Valentijn Scholten <valentijnscholten@gmail.com>