### PR TITLE
Allow cloning of ACL during Project cloning

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -121,6 +121,7 @@
     "include_components": "Include components",
     "include_services": "Include services",
     "include_audit_history": "Include audit history",
+    "include_acl": "Include access control list",
     "project_cloning_in_progress": "The project is being created with the cloning options specified",
     "vulnerability": "Vulnerability",
     "analysis": "Analysis",

--- a/src/shared/api.json
+++ b/src/shared/api.json
@@ -50,7 +50,6 @@
   "URL_POLICY_VIOLATION": "api/v1/violation",
   "URL_POLICY_VIOLATION_ANALYSIS": "api/v1/violation/analysis",
   "URL_LICENSE_GROUP": "api/v1/licenseGroup",
-  "URL_ACL_ENABLED": "api/v1/acl/enabled",
   "URL_ACL_MAPPING": "api/v1/acl/mapping",
   "URL_ACL_TEAM": "api/v1/acl/team",
   "URL_VEX": "api/v1/vex",

--- a/src/shared/api.json
+++ b/src/shared/api.json
@@ -50,6 +50,7 @@
   "URL_POLICY_VIOLATION": "api/v1/violation",
   "URL_POLICY_VIOLATION_ANALYSIS": "api/v1/violation/analysis",
   "URL_LICENSE_GROUP": "api/v1/licenseGroup",
+  "URL_ACL_ENABLED": "api/v1/acl/enabled",
   "URL_ACL_MAPPING": "api/v1/acl/mapping",
   "URL_ACL_TEAM": "api/v1/acl/team",
   "URL_VEX": "api/v1/vex",

--- a/src/views/portfolio/projects/ProjectAddVersionModal.vue
+++ b/src/views/portfolio/projects/ProjectAddVersionModal.vue
@@ -23,7 +23,7 @@
     <b-form-checkbox id="checkbox-5" v-model="includeAuditHistory" name="checkbox-5" switch
                      value="true" unchecked-value="false"> {{ $t('message.include_audit_history') }}</b-form-checkbox>
 
-    <b-form-checkbox v-show="aclEnabled" id="checkbox-6" v-model="includeACL" name="checkbox-6" switch
+    <b-form-checkbox id="checkbox-6" v-model="includeACL" name="checkbox-6" switch
                      value="true" unchecked-value="false"> {{ $t('message.include_acl') }}</b-form-checkbox>
 
     <template v-slot:modal-footer="{ cancel }">
@@ -47,30 +47,10 @@
         includeComponents: true,
         includeServices: true,
         includeAuditHistory: true,
-        includeACL: true,
-        aclEnabled: false
+        includeACL: true
       }
     },
     methods: {
-      checkACLEnabled() {
-        // alert('getting ACLEnabled from API')
-        let url = `${this.$api.BASE_URL}/${this.$api.URL_ACL_ENABLED}`;
-        this.axios.get(url
-          ).then((response) => {
-            var aclEnabledinAPI = false;
-            if (response.status === 200) {
-              // alert(response.data)
-              aclEnabledinAPI = response.data === true;
-            }
-            this.aclEnabled = aclEnabledinAPI
-            //default to not copy the ACL if ACL is disabled
-            this.includeACL = this.aclEnabled
-            return aclEnabledinAPI
-          }).catch(err => {
-            this.$toastr.w(this.$t('condition.unsuccessful_action'));
-            return Promise.reject(err);
-          });
-      },
       createVersion: function() {
         let url = `${this.$api.BASE_URL}/${this.$api.URL_PROJECT}/clone`;
         this.axios.put(url, {
@@ -99,9 +79,6 @@
         this.includeACL = true;
       }
     },
-    mounted() {
-      this.checkACLEnabled()
-    }
   }
 </script>
 


### PR DESCRIPTION
Adds an includeACL parameter to the project clone api, accompanying https://github.com/DependencyTrack/dependency-track/pull/2122

![2022-11-05 16_00_03-Dependency-Track - een ▸ develop](https://user-images.githubusercontent.com/4426050/200128744-2d373183-736b-4fe8-bf82-b3118d5b406d.png)


Signed-off-by: Valentijn Scholten [valentijnscholten@gmail.com](mailto:valentijnscholten@gmail.com)