### PR TITLE
ACL: Make project names clickable

### DIFF
--- a/src/views/administration/accessmanagement/PortfolioAccessControl.vue
+++ b/src/views/administration/accessmanagement/PortfolioAccessControl.vue
@@ -78,7 +78,7 @@ export default {
                     <b-form-group :label="this.$t('admin.project_access')">
                       <div class="list-group">
                         <span v-for="project in projects">
-                          <actionable-list-group-item :value="projectLabel(project.name, project.version)" :delete-icon="true" v-on:actionClicked="removeProjectMapping(project.uuid)"/>
+                          <actionable-list-group-item :value="projectLabel(project.name, project.version)" :href=projectUri(project.uuid) :delete-icon="true" v-on:actionClicked="removeProjectMapping(project.uuid)"/>
                         </span>
                         <actionable-list-group-item :add-icon="true" v-on:actionClicked="$root.$emit('bv::show::modal', 'selectProjectModal')"/>
                       </div>
@@ -114,6 +114,9 @@ export default {
                 } else {
                   return name;
                 }
+              },
+              projectUri: function(uuid) {
+                return xssFilters.uriInUnQuotedAttr("../projects/" + uuid);
               },
               updateProjectSelection: function(selections) {
                 this.$root.$emit('bv::hide::modal', 'selectProjectModal');

--- a/src/views/components/ActionableListGroupItem.vue
+++ b/src/views/components/ActionableListGroupItem.vue
@@ -5,18 +5,19 @@
       <span class="fa fa-trash-o" v-if="this.deleteIcon"></span>
     </b-button>
     <slot v-if="$slots && $slots.default && !!$slots.default[0]"></slot>
-    <span v-else>{{ value }}&nbsp;</span>
+    <span v-else><a v-if="this.href" :href=href>{{ value }}</a><span v-else>{{ value }}</span>&nbsp;</span>
   </li>
 </template>
 
 <script>
-  export default {
+    export default {
     props: {
       value: String,
       tooltip: String,
       addIcon: Boolean,
       deleteIcon: Boolean,
-      variant: String
+      variant: String,
+      href: String
     }
   }
 </script>


### PR DESCRIPTION
When managing ACLs, the projects assigned to teams has a non-clickable name.
It thought it might be handy to make them clickable.
I did encode the url for XSS, but I am not sure this is needed when letting Vue take care of rendering the template.
(And it would be hard to embed a XSS payload in a uuid generated by the database)

![2022-11-05 19_30_38-Dependency-Track - Administration](https://user-images.githubusercontent.com/4426050/200135703-7635138e-a24c-45ce-b563-0c50338a4e8c.png)
