### PR TITLE
Handle 404 responses from `/api/v1/analysis`

### DIFF
--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -347,7 +347,9 @@
                 getAnalysis: function() {
                   let queryString = "?project=" + projectUuid + "&component=" + this.finding.component.uuid + "&vulnerability=" + this.finding.vulnerability.uuid;
                   let url = `${this.$api.BASE_URL}/${this.$api.URL_ANALYSIS}` + queryString;
-                  this.axios.get(url).then((response) => {
+                  this.axios.get(url, {
+                    validateStatus: (status) => status === 200 || status === 404
+                  }).then((response) => {
                     this.updateAnalysisData(response.data);
                   });
                 },


### PR DESCRIPTION
### Description

Handle 404 responses from the `/api/v1/analysis` endpoint.

The endpoint previously returned HTTP 200 with an empty response body in case no analysis was found.
This has changed with https://github.com/DependencyTrack/dependency-track/pull/2196

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/1932

### Additional Details

The frontend shows an error toast whenever it encounters a non-successful response status. Using the `validateStatus` [request configuration](https://axios-http.com/docs/req_config), the 404 status code can be treated as acceptable, such that no error toast is shown anymore.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
