### PR TITLE
Improve focusing on components in dependency graph

### DIFF
--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -65,7 +65,7 @@ export default {
           this.loading = true
           let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.project.uuid}/dependencyGraph/${this.$route.params.componentUuid}`
           this.axios.get(url).then(response => {
-            if (response.data && response.data.length > 0){
+            if (response.data && Object.keys(response.data).length > 0){
               this.showCompleteGraph = false
               this.notFound = false
               this.response = response
@@ -214,24 +214,42 @@ export default {
       return children;
     },
     transformDependenciesToOrgTreeWithSearchedDependency: function (dependencies, treeNode, onlySearched) {
-      let children
-      if (dependencies) {
-        children = []
-        for (const dependency of dependencies) {
-          if (!onlySearched || (onlySearched && (dependency.expandDependencyGraph || dependency.uuid === this.$route.params.componentUuid))) {
-            let childNode = this.transformDependencyToOrgTreeWithSearchedDependency(dependency)
+      let children = []
+      let directDependencies = JSON.parse(this.project.directDependencies)
+      directDependencies.forEach((directDependency) => {
+        if (dependencies[directDependency.uuid] && (!onlySearched || (onlySearched && (dependencies[directDependency.uuid].expandDependencyGraph || directDependency.uuid === this.$route.params.componentUuid)))) {
+          let childNode = this.transformDependencyToOrgTreeWithSearchedDependency(dependencies[directDependency.uuid])
+          childNode.gatheredKeys.push(childNode.label)
+          children.push(childNode)
+          if (onlySearched && directDependency.uuid === this.$route.params.componentUuid) {
+            this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, false))
+          } else {
+            this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, onlySearched))
+          }
+        }
+      })
+      return children
+    },
+    getChildrenFromDependencyWithSearchedDependency: function (dependencies, component, treeNode, onlySearched) {
+      let children = []
+      if (component.dependencyGraph) {
+        component.dependencyGraph.forEach((dependency) => {
+          if (dependencies[dependency] && (!onlySearched || (onlySearched && (dependencies[dependency].expandDependencyGraph || dependency === this.$route.params.componentUuid)))) {
+            let childNode = this.transformDependencyToOrgTreeWithSearchedDependency(dependencies[dependency])
             for (const gatheredKey of treeNode.gatheredKeys) {
               childNode.gatheredKeys.push(gatheredKey)
             }
-            childNode.gatheredKeys.push(childNode.label)
-            children.push(childNode)
-            if (onlySearched && dependency.uuid === this.$route.params.componentUuid) {
-              this.$set(childNode, 'children', this.transformDependenciesToOrgTreeWithSearchedDependency(dependency.dependencyGraph, childNode, false))
-            } else {
-              this.$set(childNode, 'children', this.transformDependenciesToOrgTreeWithSearchedDependency(dependency.dependencyGraph, childNode, onlySearched))
+            if (!childNode.gatheredKeys.some(gatheredKey => gatheredKey === childNode.label)) {
+              childNode.gatheredKeys.push(childNode.label)
+              children.push(childNode)
+              if (onlySearched && dependency === this.$route.params.componentUuid) {
+                this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[dependency], childNode, false))
+              } else {
+                this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[dependency], childNode, onlySearched))
+              }
             }
           }
-        }
+        })
       }
       return children
     },

--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -201,14 +201,16 @@ export default {
         for(let i = 0; i < dependencies.length; i++) {
           let dependency = dependencies[i]
           let childNode = this.transformDependencyToOrgTree(dependency);
-          for (const gatheredKey of treeNode.gatheredKeys){
+          for (const gatheredKey of treeNode.gatheredKeys) {
             childNode.gatheredKeys.push(gatheredKey)
           }
-          childNode.gatheredKeys.push(childNode.label)
-          if (getChildren === true) {
-            this.getChildrenFromDependency(childNode, dependency);
+          if (!childNode.gatheredKeys.some(gatheredKey => gatheredKey === childNode.label)) {
+            childNode.gatheredKeys.push(childNode.label)
+            if (getChildren === true) {
+              this.getChildrenFromDependency(childNode, dependency);
+            }
+            children.push(childNode);
           }
-          children.push(childNode);
         }
       }
       return children;
@@ -244,6 +246,7 @@ export default {
               children.push(childNode)
               if (onlySearched && dependency === this.$route.params.componentUuid) {
                 this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[dependency], childNode, false))
+                this.collapse(childNode.children)
               } else {
                 this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[dependency], childNode, onlySearched))
               }
@@ -283,15 +286,6 @@ export default {
         let data = response.data;
         if (data && data.directDependencies) {
           let jsonObject = JSON.parse(data.directDependencies)
-          let indexes = []
-          for (let i = 0; i < jsonObject.length; i++){
-            if (treeNode.gatheredKeys.some(gatheredKey => gatheredKey === jsonObject[i].purl)){
-              indexes.unshift(i)
-            }
-          }
-          for (const index of indexes){
-            jsonObject.splice(index, 1)
-          }
           this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(jsonObject, false, treeNode) )
         }
       }
@@ -368,6 +362,7 @@ export default {
         if (child.expand) {
           child.expand = false
         }
+        child.fetchedChildren = false
         child.children && _this.collapse(child.children)
       })
     },


### PR DESCRIPTION
### Description

Improvement to #336.

Focusing on a component in the dependency graph can result in huge amounts of data being sent from the backend to pre-expand a graph, because in big nested graphs the same components can appear multiple times and the current approach of focusing on components includes every duplicate component in its response.

With this PR, the needed components for pre-expanding a graph are being de-duplicated before being sent as a response to the frontend, resulting in a huge reduction of sent data (e.g. ~50MB => ~60KB).

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Backend: [#1997](https://github.com/DependencyTrack/dependency-track/issues/1997)

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

[Backend PR](https://github.com/DependencyTrack/dependency-track/pull/2296)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
