### PR TITLE
Fix component information not showing in policy violations

### DIFF
--- a/src/views/portfolio/projects/ProjectPolicyViolations.vue
+++ b/src/views/portfolio/projects/ProjectPolicyViolations.vue
@@ -81,10 +81,8 @@ export default {
             if (row.component) {
               let url = xssFilters.uriInUnQuotedAttr("../../../components/" + row.component.uuid);
               let name = common.concatenateComponentName(null, row.component.name, row.component.version);
-              if (row.component.project.directDependencies) {
-                let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr("../../../projects/" + this.uuid + "/dependencyGraph/" + row.component.uuid)
-                return `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` + `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`;
-              }
+              let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr("../../../projects/" + this.uuid + "/dependencyGraph/" + row.component.uuid)
+              return `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` + `<a href="${url}">${xssFilters.inHTMLData(name)}</a>`;
             } else {
               return "";
             }


### PR DESCRIPTION
### Description

If a project does not have a dependency graph (or rather no direct dependencies), no component information will be shown in the `Policy Violations` tab of a project.

This PR fixes this bug by showing component information in the `Policy Violations` tab regardless of whether the project has a dependency graph or not.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Backend Issue: [#2311](https://github.com/DependencyTrack/frontend/issues/373)

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
