### PR TITLE
minor: Enabled Sorting For Project Name in ComponentSearch.vue

### DIFF
--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -150,7 +150,7 @@
           {
             title: this.$t('message.project_name'),
             field: "project.name",
-            sortable: false,
+            sortable: true,
             formatter(value, row, index) {
               let url = xssFilters.uriInUnQuotedAttr("../projects/" + row.project.uuid);
               let name = common.concatenateComponentName(null, row.project.name, row.project.version);


### PR DESCRIPTION

Signed-off-by: kekkegenkai <kekkegenkai@gmail.com>

### Description

The current "Components"-View does not allow users to sort the table by the project name.
Tis PR sets the "sortable" flag from false to true. 

The original issue (https://github.com/DependencyTrack/dependency-track/issues/353) was for the old frontend.
However, with the new frontend the issue seems to be by setting the flag.


### Addressed Issue
https://github.com/DependencyTrack/dependency-track/issues/353



### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
