### PR TITLE
Added new project notification to frontend alert template

### DIFF
--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -178,6 +178,7 @@
                           <div class="list-group-item"><b-form-checkbox value="VEX_CONSUMED">VEX_CONSUMED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="VEX_PROCESSED">VEX_PROCESSED</b-form-checkbox></div>
                           <div class="list-group-item"><b-form-checkbox value="POLICY_VIOLATION">POLICY_VIOLATION</b-form-checkbox></div>
+                          <div class="list-group-item"><b-form-checkbox value="PROJECT_CREATED">PROJECT_CREATED</b-form-checkbox></div>
                         </b-form-checkbox-group>
                       </div>
                       <div class="list-group" v-if="this.scope === 'SYSTEM'">


### PR DESCRIPTION
### Description
Added new project notification to frontend alert template, to make it selectable.

### Addressed Issue
The new PROJECT_CREATED notification is not visible in the frontend, as the frontend does not pull the list of notifications dynamically.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
