### PR TITLE
Issue-2473 : fix OSV ecosystem to be unique (frontend)

### DIFF
--- a/src/views/administration/vuln-sources/EcosystemModal.vue
+++ b/src/views/administration/vuln-sources/EcosystemModal.vue
@@ -60,7 +60,7 @@
                 name: ecosystem
             }));
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_OSV_ECOSYSTEM}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_OSV_ECOSYSTEM}/inactive`
         }
       };
     }


### PR DESCRIPTION
### Description

While selecting ecosystems for OSV mirroring, same ecosystem can be selected multiple times. This may cause duplicate downloading of one ecosystem (large files) from OSV client, which may result in repeated processing of already processed vulnerabilities.
Issue: https://github.com/DependencyTrack/dependency-track/issues/2473

### Addressed Issue

Update the endpoint to get only inactive ecosystems, to fix the selection of ecosystems to be unique. 


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
