### PR TITLE
Deep-Linking support for component search

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -124,7 +124,9 @@
         let url = this.apiUrl(project.uuid)
         await this.axios.get(url).then((response) => {
           for (let project of response.data) {
-            project.pid = MurmurHash2(project.parentUuid).result()
+            if (project.parent) {
+              project.pid = MurmurHash2(project.parent.uuid).result()
+            }
           }
           this.$refs.table.append(response.data)
         })


### PR DESCRIPTION
### Description

This PR implements the support for deep-linking to results in the component search, which makes it possible to easily share/re-use search results by copying the current URL for the result.

Two new functionalities are added to the component search for this improvement:
- If the URL contains the criteria for a search query, the query will be inserted into the component search and the search will be performed.
- Clicking on the `Search` button changes the URL in the address bar to reflect the current search criteria for the result.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

#425

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

**Examples:**
- `/components#/search/COORDINATES/group=acme/name=test/version=dev`
- `/components#/search/HASH/123456789987654321`
- `/components#/search/PACKAGE_URL/pkg%3Amaven%2Forg.yaml%2Fsnakeyaml%401.19%3Ftype%3Djar`

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
