### PR TITLE
Include outdated component in the Audit Vulnerabilities overview

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -119,6 +119,10 @@ html {
   background-color: #EBE5A8;
   border: 1px solid #DCD167;
 }
+.label-source-owasp {
+  background-color: #90a1f5;
+  border: 1px solid #4051b5;
+}
 .label-notification {
   color: #222222;
   padding: .2em .6em .3em;
@@ -464,4 +468,3 @@ td a.detail-icon {
   color: #bfcfdf;
   font-weight: 700;
 }
-

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -151,7 +151,7 @@ import common from "../../../shared/common";
                 return common.formatSourceLabel(row.vulnerability.source) + ` <a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
               } else {
                 // outdated component
-                return xssFilters.inHTMLData("Outdated Component");
+                return common.formatSourceLabel("OWASP") + ` <a href="https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/" target="_blank">${xssFilters.inHTMLData("Outdated Component")} <i class="fa fa-external-link"></i></a>`;
               }
             }
           },


### PR DESCRIPTION
### Description

The Audit Vulnerabilities overview now takes outdated component into account.

![image](https://user-images.githubusercontent.com/11032733/222891065-f0cdd36d-b65f-4283-b946-2cea4d3b55ad.png)


### Addressed Issue

Closes #434

### Additional Details

Uses, but does not need new API: https://github.com/DependencyTrack/dependency-track/pull/2521

No documentation updated, I think exisiting documentation already covers this.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
