### PR TITLE
Fix duplicate version in affected components tab

### DIFF
--- a/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
@@ -1244,7 +1244,7 @@ export default {
           s += "|<=" + affectedComponent.versionEndIncluding;
         }
         s += " )";
-      } else if (affectedComponent.versionType === 'EXACT') {
+      } else if (affectedComponent.versionType === 'EXACT' && !s.includes("@")) {
         s += "@"+affectedComponent.version;
       }
       return s;


### PR DESCRIPTION
### Description

For exact versions in affected components, if purl has version already appended, the frontend was appending the version again making it look like test-purl@3.4@3.4

### Addressed Issue

Quick fix to add a check to avoid double version append.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
