### PR TITLE
Issue 2255: fetch all node children of dependency graph in one request

### DIFF
--- a/src/shared/api.json
+++ b/src/shared/api.json
@@ -30,6 +30,7 @@
   "URL_LICENSE_CONCISE": "api/v1/license/concise",
   "URL_CWE": "api/v1/cwe",
   "URL_COMPONENT": "api/v1/component",
+  "URL_DEPENDENCY_GRAPH": "api/v1/dependencyGraph",
   "URL_SERVICE": "api/v1/service",
   "URL_VULNERABILITY": "api/v1/vulnerability",
   "URL_ANALYSIS": "api/v1/analysis",

--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -100,7 +100,7 @@ export default {
                 id: this.nodeId,
                 label: this.createNodeLabel(this.project),
                 objectType: "PROJECT",
-                children: this.transformDependenciesToOrgTree(JSON.parse(this.project.directDependencies), true, {gatheredKeys: []}),
+                children: this.transformDependenciesToOrgTree(JSON.parse(this.project.directDependencies), true, {gatheredKeys: []}, this.project.uuid, "PROJECT"),
                 fetchedChildren: true
               }
               this.loading = false
@@ -121,7 +121,7 @@ export default {
             id: this.nodeId,
             label: this.createNodeLabel(this.project),
             objectType: "PROJECT",
-            children: this.transformDependenciesToOrgTree(JSON.parse(this.project.directDependencies), true, {gatheredKeys: []}),
+            children: this.transformDependenciesToOrgTree(JSON.parse(this.project.directDependencies), true, {gatheredKeys: []}, this.project.uuid, "PROJECT"),
             fetchedChildren: true
           }
         } else {
@@ -228,23 +228,24 @@ export default {
       this.$el.style.cursor = 'grab';
       this.$el.style.removeProperty('user-select');
     },
-    transformDependenciesToOrgTree: function(dependencies, getChildren, treeNode) {
+    transformDependenciesToOrgTree: function (dependencies, getChildren, treeNode, parentUuid, objectType) {
       let children = null;
       if (dependencies && dependencies.length > 0) {
         children = [];
-        for(let i = 0; i < dependencies.length; i++) {
+        for (let i = 0; i < dependencies.length; i++) {
           let dependency = dependencies[i]
           let childNode = this.transformDependencyToOrgTree(dependency);
           for (const gatheredKey of treeNode.gatheredKeys) {
             childNode.gatheredKeys.push(gatheredKey)
           }
           if (!childNode.gatheredKeys.some(gatheredKey => gatheredKey === childNode.label)) {
-            childNode.gatheredKeys.push(childNode.label)
-            if (getChildren === true) {
-              this.getChildrenFromDependency(childNode, dependency);
-            }
+            childNode.gatheredKeys.push(childNode.label);
             children.push(childNode);
           }
+        }
+
+        if (getChildren === true) {
+          this.getChildrens(children, parentUuid, objectType);
         }
       }
       return children;
@@ -315,27 +316,42 @@ export default {
         fetchedChildren: dependency.expandDependencyGraph,
         gatheredKeys: [],
         expand: dependency.expandDependencyGraph,
-        repositoryMeta: dependency.repositoryMeta
+        latestVersion: dependency.latestVersion
       }
     },
-    getChildrenFromDependency: function(treeNode, dependency) {
-      let dependencyFunc = async() => {
-        let url = this.getDependencyUrl(dependency);
+    getChildrens: function (treeNodes, parentUuid, objectType) {
+      let dependenciesFunc = async () => {
+        let url = this.getDependenciesUrl(parentUuid, objectType);
+
+        let treeNodeMap = new Map();
+
+        for (let treeNode of treeNodes) {
+          treeNodeMap.set(treeNode.uuid, treeNode);
+        }
+
         let response = await this.axios.get(url);
         let data = response.data;
-        treeNode.repositoryMeta = data.repositoryMeta
-        if (data && data.directDependencies) {
-          let jsonObject = JSON.parse(data.directDependencies)
-          this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(jsonObject, false, treeNode) )
+        let dependencies = [...data];
+        if (dependencies.length > 0) {
+          for (let dependency of dependencies) {
+            if (dependency && dependency.directDependencies) {
+              let treeNode = treeNodeMap.get(dependency.uuid);
+              treeNode.latestVersion = dependency.latestVersion;
+              let jsonObject = JSON.parse(dependency.directDependencies);
+              this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(jsonObject, false, treeNode, dependency.uuid, "COMPONENT"));
+            }
+          }
         }
       }
-      return dependencyFunc();
+      return dependenciesFunc();
     },
-    getDependencyUrl(dependency) {
-      if (dependency.objectType === "COMPONENT") {
-        return `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/${dependency.uuid}?includeRepositoryMetaData=true`;
+    getDependenciesUrl(parentUuid, objectType) {
+      if (objectType === "PROJECT") {
+        return `${this.$api.BASE_URL}/${this.$api.URL_DEPENDENCY_GRAPH}/project/${parentUuid}/directDependencies`;
+      } else if (objectType === "COMPONENT") {
+        return `${this.$api.BASE_URL}/${this.$api.URL_DEPENDENCY_GRAPH}/component/${parentUuid}/directDependencies`;
       } else {
-        return `${this.$api.BASE_URL}/${this.$api.URL_SERVICE}/${dependency.uuid}`;
+        return null
       }
     },
     createNodeLabel: function(identity) { // could be a project or a component
@@ -365,8 +381,8 @@ export default {
       }
     },
     renderContent: function(h, data) {
-      if (this.highlightOutdatedComponents && data.repositoryMeta && data.repositoryMeta.latestVersion && data.repositoryMeta.latestVersion !== data.version) {
-        return (<div style="white-space: nowrap;">{data.label + ' '}<i id={"icon"+data.id} class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i><b-tooltip target={"icon"+data.id} triggers="hover" noninteractive="noninteractive">{"Risk: Outdated component. Current version is: "+ xssFilters.inHTMLData(data.repositoryMeta.latestVersion)}</b-tooltip></div>)
+      if (this.highlightOutdatedComponents && data.version && data.latestVersion && data.latestVersion !== data.version) {
+        return (<div style="white-space: nowrap;">{data.label + ' '}<i id={"icon"+data.id} class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i><b-tooltip target={"icon"+data.id} triggers="hover" noninteractive="noninteractive">{"Risk: Outdated component. Current version is: "+ xssFilters.inHTMLData(data.latestVersion)}</b-tooltip></div>)
       } else {
         return (<div style="white-space: nowrap;">{data.label}</div>)
       }
@@ -374,8 +390,8 @@ export default {
     onExpand: async function (e, data) {
       if (!data.fetchedChildren) {
         e.target.style.cursor = "wait"
-        for (const child of data.children) {
-          await this.getChildrenFromDependency(child, child)
+        if (data.objectType === 'COMPONENT') {
+          await this.getChildrens(data.children, data.uuid, data.objectType);
         }
         data.fetchedChildren = true
         e.target.style.cursor = "pointer"


### PR DESCRIPTION
### Description

In this PR, I change the way the frontend collect information about children node in the Dependency Graph.
Before, for each child, a request to the backend was made. In this PR, I merge all requests in one on a new endpoint created in this PR: https://github.com/DependencyTrack/dependency-track/pull/2623


### Addressed Issue

fixes https://github.com/DependencyTrack/dependency-track/issues/2255

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
