### PR TITLE
fix: require VIEW_PORTFOLIO permission for BOM download

### DIFF
--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -18,7 +18,7 @@
           <span class="fa fa-upload"></span> {{ $t('message.upload_bom') }}
         </b-button>
         <b-tooltip target="upload-button" triggers="hover focus">{{ $t('message.upload_bom_tooltip') }}</b-tooltip>
-        <b-dropdown variant="outline-primary" v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT">
+        <b-dropdown variant="outline-primary" v-permission="PERMISSIONS.VIEW_PORTFOLIO">
           <template #button-content>
             <span class="fa fa-download"></span> {{ $t('message.download_bom') }}
           </template>


### PR DESCRIPTION
### Description

Currently the frontend requires a different permission to download a bom than the backend.
https://github.com/DependencyTrack/dependency-track/blob/4.7.1/src/main/java/org/dependencytrack/resources/v1/BomResource.java#L95
Require the VIEW_PORTFOLIE instead of PORTFOLIO_MANAGEMENT permission in the frontend for bom download

### Addressed Issue

[#2053](https://github.com/DependencyTrack/dependency-track/issues/2053)

### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
