### PR TITLE
Fix not all vulnerability aliases being displayed

### DIFF
--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -191,32 +191,55 @@ $common.resolveSourceVulnInfo = function resolveSourceVulnInfo(vulnSource, vulnI
   return sourceInfo;
 }
 
-/**
- * Given the source of a vulnerability (vulnSource) and an alias of the vulnerability, normalizes
- * the return object.
- * @param vulnSource the source of a Vulnerability object
- * @param alias a VulnerabilityAlias response object for the given Vulnerability
- * @returns A resolved and normalized object with metadata
- */
-$common.resolveVulnAliasInfo = function resolveVulnAliasInfo(vulnSource, alias) {
-  if (!vulnSource || !alias) return;
-  if (vulnSource !== "INTERNAL" && alias.internalId) {
-    return $common.resolveSourceVulnInfo("INTERNAL", alias.internalId);
-  } else if (vulnSource !== "NVD" && alias.cveId) {
-    return $common.resolveSourceVulnInfo("NVD", alias.cveId);
-  } else if (vulnSource !== "GITHUB" && alias.ghsaId) {
-    return $common.resolveSourceVulnInfo("GITHUB", alias.ghsaId);
-  } else if (vulnSource !== "OSSINDEX" && alias.sonatypeId) {
-    return $common.resolveSourceVulnInfo("OSSINDEX", alias.sonatypeId);
-  } else if (vulnSource !== "SNYK" && alias.snykId) {
-    return $common.resolveSourceVulnInfo("SNYK", alias.snykId);
-  } else if (vulnSource !== "OSV" && alias.osvId) {
-    return $common.resolveSourceVulnInfo("OSV", alias.osvId);
-  } else if (vulnSource !== "GSD" && alias.gsdId) {
-    return $common.resolveSourceVulnInfo("GSD", alias.gsdId);
-  } else if (vulnSource !== "VULNDB" && alias.vulnDbId) {
-    return $common.resolveSourceVulnInfo("VULNDB", alias.vulnDbId);
+$common.resolveVulnAliases = function resolveVulnAliases(vulnSource, aliases) {
+  if (!vulnSource || !aliases) {
+    return [];
   }
+
+  let resolvedAliases = aliases
+    .flatMap((alias) => {
+      const _resolvedAliases = [];
+      if (vulnSource !== "INTERNAL" && alias.internalId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("INTERNAL", alias.internalId));
+      }
+      if (vulnSource !== "NVD" && alias.cveId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("NVD", alias.cveId));
+      }
+      if (vulnSource !== "GITHUB" && alias.ghsaId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("GITHUB", alias.ghsaId));
+      }
+      if (vulnSource !== "OSSINDEX" && alias.sonatypeId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("OSSINDEX", alias.sonatypeId));
+      }
+      if (vulnSource !== "SNYK" && alias.snykId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("SNYK", alias.snykId));
+      }
+      if (vulnSource !== "OSV" && alias.osvId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("OSV", alias.osvId));
+      }
+      if (vulnSource !== "GSD" && alias.gsdId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("GSD", alias.gsdId));
+      }
+      if (vulnSource !== "VULNDB" && alias.vulnDbId) {
+        _resolvedAliases.push($common.resolveSourceVulnInfo("VULNDB", alias.vulnDbId));
+      }
+      return _resolvedAliases;
+    });
+
+  // Deduplicate by vulnerability ID, so we're not showing the same ID more than once.
+  resolvedAliases = [...new Map(resolvedAliases.map(alias => [alias.vulnId, alias])).values()];
+
+  // Sort aliases by vulnerability ID to achieve consistent output.
+  return resolvedAliases
+    .sort((a, b) => {
+      if (a.vulnId < b.vulnId) {
+        return -1;
+      }
+      if (a.vulnId > b.vulnId) {
+        return 1;
+      }
+      return 0;
+    });
 }
 
 /**
@@ -473,7 +496,7 @@ export default {
   formatCweShortLabel: $common.formatCweShortLabel,
   formatAnalyzerLabel: $common.formatAnalyzerLabel,
   resolveSourceVulnInfo: $common.resolveSourceVulnInfo,
-  resolveVulnAliasInfo: $common.resolveVulnAliasInfo,
+  resolveVulnAliases: $common.resolveVulnAliases,
   makeAnalysisStateLabelFormatter: $common.makeAnalysisStateLabelFormatter,
   makeAnalysisJustificationLabelFormatter: $common.makeAnalysisJustificationLabelFormatter,
   componentClassifierLabelFormatter: $common.componentClassifierLabelFormatter,

--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -45,11 +45,12 @@
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {
                 let label = "";
-                for (let i=0; i<value.length; i++) {
-                  let alias = common.resolveVulnAliasInfo(row.source, value[i]);
+                const aliases = common.resolveVulnAliases(row.source, value);
+                for (let i=0; i<aliases.length; i++) {
+                  let alias = aliases[i];
                   let url = xssFilters.uriInUnQuotedAttr("../vulnerabilities/" + alias.source + "/" + alias.vulnId);
                   label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
-                  if (i < value.length-1) label += "<br/><br/>"
+                  if (i < aliases.length-1) label += "<br/><br/>"
                 }
                 return label;
               }

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -144,11 +144,12 @@
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {
                 let label = "";
-                for (let i=0; i<value.length; i++) {
-                  let alias = common.resolveVulnAliasInfo(row.vulnerability.source, value[i]);
+                const aliases = common.resolveVulnAliases(row.vulnerability.source, value);
+                for (let i=0; i<aliases.length; i++) {
+                  let alias = aliases[i];
                   let url = xssFilters.uriInUnQuotedAttr("../../../vulnerabilities/" + alias.source + "/" + alias.vulnId);
                   label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
-                  if (i < value.length-1) label += "<br/><br/>"
+                  if (i < aliases.length-1) label += "<br/><br/>"
                 }
                 return label;
               }
@@ -248,9 +249,9 @@
                     <label>Aliases</label>
                       <b-card class="font-weight-bold">
                         <b-card-text>
-                          <span v-for="alias in finding.vulnerability.aliases">
-                          <b-link style="margin-right:1.0rem" :href="'/vulnerabilities/' + aliasLabel(finding.vulnerability.source, alias).source + '/' + aliasLabel(finding.vulnerability.source, alias).vulnId">{{aliasLabel(finding.vulnerability.source, alias).vulnId}}</b-link>
-                         </span>
+                          <span v-for="alias in resolveVulnAliases(finding.vulnerability.aliases)">
+                          <b-link style="margin-right:1.0rem" :href="'/vulnerabilities/' + alias.source + '/' + alias.vulnId">{{ alias.vulnId }}</b-link>
+                          </span>
                         </b-card-text>
                      </b-card>
                     </div>
@@ -364,8 +365,8 @@
               },
               mixins: [permissionsMixin],
               methods: {
-                aliasLabel: function(vulnSource, alias) {
-                  return common.resolveVulnAliasInfo(vulnSource, alias);
+                resolveVulnAliases: function(aliases) {
+                  return common.resolveVulnAliases(this.source, aliases);
                 },
                 getAnalysis: function() {
                   let queryString = "?project=" + projectUuid + "&component=" + this.finding.component.uuid + "&vulnerability=" + this.finding.vulnerability.uuid;

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -39,8 +39,8 @@
           <span v-if="vulnerability.published" class="font-weight-bold font-xs" style="margin-right:1.2rem">{{prettyTimestamp}}</span>
           <span v-if="vulnerability.aliases && vulnerability.aliases.length > 0" class="font-weight-bold font-xs">
             Aliases:
-            <span v-for="alias in vulnerability.aliases">
-              <b-link style="margin-right:1.0rem" :href="`/vulnerabilities/${aliasLabel(alias).source}/${aliasLabel(alias).vulnId}`">{{ aliasLabel(alias).vulnId }}</b-link>
+            <span v-for="alias in resolveVulnAliases(vulnerability.aliases)">
+              <b-link style="margin-right:1.0rem" :href="`/vulnerabilities/${alias.source}/${alias.vulnId}`">{{ alias.vulnId }}</b-link>
             </span>
           </span>
         </b-card-text>
@@ -274,8 +274,8 @@
       cweLink: function(cwe) {
         return `https://cwe.mitre.org/data/definitions/${cwe.cweId}`;
       },
-      aliasLabel: function(alias) {
-        return common.resolveVulnAliasInfo(this.source, alias);
+      resolveVulnAliases: function(aliases) {
+        return common.resolveVulnAliases(this.source, aliases);
       },
       loadData: function () {
         let url = "";

--- a/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
@@ -31,8 +31,8 @@
           </b-row>
           <b-form-group :label="this.$t('message.aliases')">
             <div class="list-group">
-                        <span v-for="alias in vulnerability.aliases">
-                          <actionable-list-group-item :value="aliasLabel(alias).vulnId" :delete-icon="false"/>
+                        <span v-for="alias in resolveVulnAliases(vulnerability.aliases)">
+                          <actionable-list-group-item :value="alias.vulnId" :delete-icon="false"/>
                         </span>
               <actionable-list-group-item :add-icon="!isReadonly" v-on:actionClicked="$root.$emit('bv::show::modal', 'selectCweModal')"/>
             </div>
@@ -897,8 +897,8 @@ export default {
     }
   },
   methods: {
-    aliasLabel: function(alias) {
-      return common.resolveVulnAliasInfo(this.vulnerability.source, alias);
+    resolveVulnAliases: function(aliases) {
+      return common.resolveVulnAliases(this.vulnerability.source, aliases);
     },
     onShow: function() {
       this.parseCvssV2Vector();

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -68,11 +68,12 @@
             formatter(value, row, index) {
               if (typeof value !== 'undefined') {
                 let label = "";
-                for (let i=0; i<value.length; i++) {
-                  let alias = common.resolveVulnAliasInfo(row.source, value[i]);
+                const aliases = common.resolveVulnAliases(value);
+                for (let i=0; i<aliases.length; i++) {
+                  let alias = aliases[i];
                   let url = xssFilters.uriInUnQuotedAttr("../vulnerabilities/" + alias.source + "/" + alias.vulnId);
                   label += common.formatSourceLabel(alias.source) + ` <a href="${url}">${xssFilters.inHTMLData(alias.vulnId)}</a>`
-                  if (i < value.length-1) label += "<br/><br/>"
+                  if (i < aliases.length-1) label += "<br/><br/>"
                 }
                 return label;
               }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes a defect where not all aliases of vulnerabilities would be displayed. See #477 for details.

This PR also prevents the same vulnerability ID being displayed multiple times, and adds sorting of alias IDs so that the output is more visually consistent.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #477

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

![image](https://user-images.githubusercontent.com/5693141/233854499-dc7d1be4-3df5-4909-9035-92ae08a63264.png)

![image](https://user-images.githubusercontent.com/5693141/233854514-05a3a968-b340-4853-8e30-d6861713e9c1.png)

![image](https://user-images.githubusercontent.com/5693141/233854519-ac856e9f-1341-4508-a1ed-ff1a18245d33.png)

![image](https://user-images.githubusercontent.com/5693141/233854530-3ca4222f-94ee-45e7-aa9c-3fce0732a1fe.png)


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
