### PR TITLE
Add external references and description to project page

### DIFF
--- a/src/views/components/ExternalReferencesDropdown.vue
+++ b/src/views/components/ExternalReferencesDropdown.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <span><i class="fa fa-link text-muted" v-b-tooltip.hover="{title: $t('message.external_references')}"></i></span>
+    <ol style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
+      <li class="dropdown">
+        <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
+        <ul class="dropdown-menu">
+          <span v-for="r in externalReferences" :key="r.url">
+            <b-dropdown-item target="_blank" :href="r.url" v-b-tooltip.hover="{placement: 'left', title: r.url}">
+              <i class="fa fa-external-link text-muted"></i>&nbsp;
+              <span v-if="typeAcronyms.includes(r.type)" class="text-uppercase">{{ r.type }}</span>
+              <span v-else class="text-capitalize">{{ r.type }}</span>
+            </b-dropdown-item>
+          </span>
+        </ul>
+      </li>
+    </ol>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      externalReferences: Object
+    },
+    data() {
+      return {
+        // acronyms should be shown as uppercase letters, other types just be capitalized
+        typeAcronyms: ['bom', 'poam', 'vcs']
+      }
+    }
+  }
+</script>

--- a/src/views/portfolio/projects/Component.vue
+++ b/src/views/portfolio/projects/Component.vue
@@ -75,7 +75,30 @@
         </b-row>
       </b-card-body>
       <div id="component-info-footer" slot="footer">
-        <b-link class="font-weight-bold font-xs btn-block text-muted" v-b-modal.componentDetailsModal>{{ $t('message.view_details') }} <i class="fa fa-angle-right float-right font-lg"></i></b-link>
+        <b-row>
+          <b-col>
+            <b-link class="font-weight-bold font-xs btn-block text-muted" v-b-modal.componentDetailsModal>{{ $t('message.view_details') }} <i class="fa fa-angle-right float-right font-lg"></i></b-link>
+          </b-col>
+          <b-col v-if="component.externalReferences" md="auto">
+            <b-row class="d-none d-md-flex float-right">
+              <div>
+                <span><i class="fa fa-link text-muted" v-b-tooltip.hover="{title: $t('message.external_references')}"></i></span>
+                <ol style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
+                  <li class="dropdown">
+                    <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
+                    <ul class="dropdown-menu">
+                      <span v-for="r in component.externalReferences" :key="r.url">
+                        <b-dropdown-item target="_blank" :href="r.url" v-b-tooltip.hover="{placement: 'left', title: r.url}">
+                          <i class="fa fa-external-link text-muted"></i>&nbsp;<span class="text-capitalize">{{ r.type }}</span>
+                        </b-dropdown-item>
+                      </span>
+                    </ul>
+                  </li>
+                </ol>
+              </div>
+            </b-row>
+          </b-col>
+        </b-row>
       </div>
     </b-card>
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">

--- a/src/views/portfolio/projects/Component.vue
+++ b/src/views/portfolio/projects/Component.vue
@@ -81,21 +81,7 @@
           </b-col>
           <b-col v-if="component.externalReferences" md="auto">
             <b-row class="d-none d-md-flex float-right">
-              <div>
-                <span><i class="fa fa-link text-muted" v-b-tooltip.hover="{title: $t('message.external_references')}"></i></span>
-                <ol style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
-                  <li class="dropdown">
-                    <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
-                    <ul class="dropdown-menu">
-                      <span v-for="r in component.externalReferences" :key="r.url">
-                        <b-dropdown-item target="_blank" :href="r.url" v-b-tooltip.hover="{placement: 'left', title: r.url}">
-                          <i class="fa fa-external-link text-muted"></i>&nbsp;<span class="text-capitalize">{{ r.type }}</span>
-                        </b-dropdown-item>
-                      </span>
-                    </ul>
-                  </li>
-                </ol>
-              </div>
+              <ExternalReferencesDropdown :externalReferences="component.externalReferences" />
             </b-row>
           </b-col>
         </b-row>
@@ -127,6 +113,7 @@
   import EventBus from '../../../shared/eventbus';
   import permissionsMixin from "../../../mixins/permissionsMixin";
   import ComponentDetailsModal from "./ComponentDetailsModal";
+  import ExternalReferencesDropdown from "../../components/ExternalReferencesDropdown.vue";
 
   export default {
     mixins: [permissionsMixin],
@@ -136,7 +123,8 @@
       ComponentVulnerabilities,
       PortfolioWidgetRow,
       VueEasyPieChart,
-      ComponentDetailsModal
+      ComponentDetailsModal,
+      ExternalReferencesDropdown
     },
     title: '',
     computed: {

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -124,7 +124,7 @@
               </div>
             </b-row>
           </b-col>
-      </b-row>
+        </b-row>
       </div>
     </b-card>
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -6,26 +6,35 @@
           <b-col>
             <i class="fa fa-sitemap bg-primary p-3 font-2xl mr-3 float-left"></i>
             <div class="h5 mb-0 mt-2">
-              {{ project.name }}
-              <ol v-if="project.version" style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
-                <li class="dropdown">
-                  <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
-                  <ul class="dropdown-menu">
-                    <span v-for="p in availableProjectVersions">
-                      <b-dropdown-item :to="{name: 'Project', params: {'uuid': p.uuid}}">{{ p.version }}</b-dropdown-item>
-                      </span>
-                  </ul>
-                </li>
-              </ol>
-              {{ project.version }}
+              <b-row>
+                <b-col class="text-nowrap" md="auto">
+                  {{ project.name }}
+                  <ol v-if="project.version" style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
+                    <li class="dropdown">
+                      <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
+                      <ul class="dropdown-menu">
+                        <span v-for="p in availableProjectVersions">
+                          <b-dropdown-item :to="{name: 'Project', params: {'uuid': p.uuid}}">{{ p.version }}</b-dropdown-item>
+                          </span>
+                      </ul>
+                    </li>
+                  </ol>
+                  {{ project.version }}
+                </b-col>
+                <b-col class="d-none d-md-flex">
+                  <span class="text-muted font-xs font-italic align-text-top text-truncate" style="max-width: 100ch;" v-b-tooltip.hover="{title: project.description}">{{ project.description }}</span>
+                </b-col>
+              </b-row>
             </div>
-            <div class="text-muted text-lowercase font-weight-bold font-xs">
-              <span v-for="tag in project.tags">
-                <b-badge :to="{name: 'Projects', query: {'tag': tag.name}}" variant="tag">{{ tag.name }}</b-badge>
+            <div class="text-muted font-xs">
+              <span class="text-lowercase font-weight-bold">
+                <span v-for="tag in project.tags">
+                  <b-badge :to="{name: 'Projects', query: {'tag': tag.name}}" variant="tag">{{ tag.name }}</b-badge>
+                </span>
               </span>
             </div>
           </b-col>
-          <b-col>
+          <b-col md="auto">
             <b-row class="d-none d-md-flex float-right">
               <vue-easy-pie-chart style="margin-right: 1rem"
                                   :bar-color="severityCritical"

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -92,7 +92,30 @@
         </b-row>
       </b-card-body>
       <div id="project-info-footer" slot="footer">
-        <b-link class="font-weight-bold font-xs btn-block text-muted" @click="initializeProjectDetailsModal">{{ $t('message.view_details') }} <i class="fa fa-angle-right float-right font-lg"></i></b-link>
+        <b-row>
+          <b-col>
+            <b-link class="font-weight-bold font-xs btn-block text-muted" @click="initializeProjectDetailsModal">{{ $t('message.view_details') }} <i class="fa fa-angle-right float-right font-lg"></i></b-link>
+          </b-col>
+          <b-col v-if="project.externalReferences" md="auto">
+            <b-row class="d-none d-md-flex float-right">
+              <div>
+                <span><i class="fa fa-link text-muted" v-b-tooltip.hover="{title: $t('message.external_references')}"></i></span>
+                <ol style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
+                  <li class="dropdown">
+                    <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
+                    <ul class="dropdown-menu">
+                      <span v-for="r in project.externalReferences" :key="r.url">
+                        <b-dropdown-item target="_blank" :href="r.url" v-b-tooltip.hover="{placement: 'left', title: r.url}">
+                          <i class="fa fa-external-link text-muted"></i>&nbsp;<span class="text-capitalize">{{ r.type }}</span>
+                        </b-dropdown-item>
+                      </span>
+                    </ul>
+                  </li>
+                </ol>
+              </div>
+            </b-row>
+          </b-col>
+      </b-row>
       </div>
     </b-card>
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -107,21 +107,7 @@
           </b-col>
           <b-col v-if="project.externalReferences" md="auto">
             <b-row class="d-none d-md-flex float-right">
-              <div>
-                <span><i class="fa fa-link text-muted" v-b-tooltip.hover="{title: $t('message.external_references')}"></i></span>
-                <ol style="display: inline-block; margin: 0; list-style-type: none; padding-inline-start: 0">
-                  <li class="dropdown">
-                    <a href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-caret-down" aria-hidden="true" style="padding-left:10px; padding-right:10px; padding-top:3px; padding-bottom:3px;"></i></a>
-                    <ul class="dropdown-menu">
-                      <span v-for="r in project.externalReferences" :key="r.url">
-                        <b-dropdown-item target="_blank" :href="r.url" v-b-tooltip.hover="{placement: 'left', title: r.url}">
-                          <i class="fa fa-external-link text-muted"></i>&nbsp;<span class="text-capitalize">{{ r.type }}</span>
-                        </b-dropdown-item>
-                      </span>
-                    </ul>
-                  </li>
-                </ol>
-              </div>
+              <ExternalReferencesDropdown :externalReferences="project.externalReferences" />
             </b-row>
           </b-col>
         </b-row>
@@ -184,6 +170,7 @@
   import ProjectFindings from "./ProjectFindings";
   import ProjectPolicyViolations from "./ProjectPolicyViolations";
   import ProjectEpss from "./ProjectEpss";
+  import ExternalReferencesDropdown from "../../components/ExternalReferencesDropdown.vue";
 
   export default {
     mixins: [permissionsMixin],
@@ -201,7 +188,8 @@
       ProjectDashboard,
       PortfolioWidgetRow,
       VueEasyPieChart,
-      ProjectEpss
+      ProjectEpss,
+      ExternalReferencesDropdown
     },
     title: '',
     computed: {


### PR DESCRIPTION
## Description

As a comfort function, it would be great to have the external references as well as the description of a project available on the project page header.

## Addressed Issue

* resolves https://github.com/DependencyTrack/frontend/issues/484
* resolves https://github.com/DependencyTrack/frontend/issues/487

## Additional Details

### External references

On projects and components containing external references the following drop down menu is shown on the right side of the "details" lane:

![image](https://user-images.githubusercontent.com/40993644/235678707-d33a414b-88ec-49c7-92af-b1791b350de4.png)

Opening the drop-down shows the link types with the url as hover tooltip, links are opened in new browser tabs:

![image](https://github.com/DependencyTrack/frontend/assets/40993644/73e63019-01a4-4e66-833d-0923a949564d)

![image](https://github.com/DependencyTrack/frontend/assets/40993644/cb438607-5cc3-4e3b-97b7-a1e7c880009f)

Projects/Components without external references keep unchanged:

![image](https://user-images.githubusercontent.com/40993644/235178829-49147741-f33c-4791-bdec-7e12046295fc.png)

![image](https://github.com/DependencyTrack/frontend/assets/40993644/0a045004-3100-4020-90c4-91607c4807ae)

### Project description

Project with a tags and long description:

![image](https://github.com/DependencyTrack/frontend/assets/40993644/c5e6d25c-c15a-4f80-91ba-323de1b681d9)

Full description via tooltip:
![image](https://github.com/DependencyTrack/frontend/assets/40993644/1e316820-9827-4299-a973-517c37d5ca93)

Description gets inlined when shrinking the page:
![image](https://github.com/DependencyTrack/frontend/assets/40993644/2a33769f-a780-4e5b-8786-b747422fc9ff)

and disappears completely on even smaller pages, like the metrics do.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
