### PR TITLE
Fix incorrect project tag links

### DIFF
--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -35,11 +35,11 @@ $common.formatNotificationLabel = function formatNotificationLabel(violationStat
 /**
  * Formats and returns a specialized label for a project tag.
  */
-$common.formatProjectTagLabel = function formatProjectTagLabel(tag) {
+$common.formatProjectTagLabel = function formatProjectTagLabel(router, tag) {
   if (! tag) {
     return "";
   }
-  return `<a href="../projects/?tag=${xssFilters.uriComponentInUnQuotedAttr(tag.name)}" class="badge badge-tag text-lowercase mr-1">${xssFilters.inHTMLData(tag.name)}</a>`
+  return `<a href="${router.resolve({name: 'Projects', query: {'tag': tag.name}}).href}" class="badge badge-tag text-lowercase mr-1">${xssFilters.inHTMLData(tag.name)}</a>`
 };
 
 /**

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -21,7 +21,7 @@
             </div>
             <div class="text-muted text-lowercase font-weight-bold font-xs">
               <span v-for="tag in project.tags">
-                <b-badge :to="{path: '../projects/', query: {'tag': tag.name}}" variant="tag">{{ tag.name }}</b-badge>
+                <b-badge :to="{name: 'Projects', query: {'tag': tag.name}}" variant="tag">{{ tag.name }}</b-badge>
               </span>
             </div>
           </b-col>

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -184,13 +184,15 @@
             field: "tags",
             sortable: false,
             visible: false,
+            routerFunc: () => this.$router, // Injecting $router directly causes recursion errors in Vue...
             formatter(value, row, index) {
+              const router = this.routerFunc();
               let tag_string = ""
               if (row.tags) {
-                tag_string = row.tags?.slice(0, 2).map(tag => common.formatProjectTagLabel(tag)).join(' ') || '';
+                tag_string = row.tags?.slice(0, 2).map(tag => common.formatProjectTagLabel(router, tag)).join(' ') || '';
                 if (row.tags.length > 2) {
                   tag_string += ` <span class="d-none">`
-                  tag_string += row.tags.slice(2)?.map(tag => common.formatProjectTagLabel(tag)).join(' ');
+                  tag_string += row.tags.slice(2)?.map(tag => common.formatProjectTagLabel(router, tag)).join(' ');
                   tag_string += `</span>`
                   tag_string += `<a href="#" title="show all tags" class="badge badge-tag" onclick="this.previousElementSibling.classList.toggle('d-none')">…</a>`
                 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes incorrect tag links being generated on the project page.

Instead of using relative URLs, make use of the Vue router to refer to the target route by name.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #483

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
