### PR TITLE
fix: no defined permission for dashboard

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -88,7 +88,8 @@ function configRoutes() {
           meta: {
             title: i18n.t('message.dashboard'),
             i18n: 'message.dashboard',
-            sectionPath: '/dashboard'
+            sectionPath: '/dashboard',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {


### PR DESCRIPTION
### Description
dashboard was treated as a public route although it's not

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
fixes regression from f16c314f4e0fde8c04d6b983fbff2f283b96c8b2

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

Since #502, any route without the `meta.permission` property is treated as a public route. I did not check the dashboard route to see if it met this requirement. As a result, when calling the dashboard, there was no redirection to the login page if you were logged out, which caused consecutive errors on the dashboard page.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
