### PR TITLE
Check /proc/mounts instead of mount

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Check if config.json is mounted
-if mount | grep '/static/config.json'; then
+if cat /proc/mounts | grep '/static/config.json'; then
   echo "config.json is mounted from host - ENV configuration will be ignored"
 else
   # Apply ENV vars to temporary config.json

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,12 +3,12 @@
 set -e
 
 # Check if config.json is mounted
-if cat /proc/mounts | grep '/static/config.json'; then
+if grep '/static/config.json' /proc/mounts; then
   echo "config.json is mounted from host - ENV configuration will be ignored"
 else
   # Apply ENV vars to temporary config.json
   jq '.API_BASE_URL = env.API_BASE_URL
-        | .API_WITH_CREDENTIALS = env.API_WITH_CREDENTIALS 
+        | .API_WITH_CREDENTIALS = env.API_WITH_CREDENTIALS
         | .OIDC_ISSUER = env.OIDC_ISSUER
         | .OIDC_CLIENT_ID = env.OIDC_CLIENT_ID
         | .OIDC_SCOPE = env.OIDC_SCOPE


### PR DESCRIPTION
### Description

We could use `cat /proc/mounts` as workaround  in case that the `mount` command does not work in some environments

### Addressed Issue

#513 

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
