### PR TITLE
Fix aliases not being displayed in expanded rows of findings table

### DIFF
--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -252,7 +252,7 @@ import common from "../../../shared/common";
                     <label>Aliases</label>
                       <b-card class="font-weight-bold">
                         <b-card-text>
-                          <span v-for="alias in resolveVulnAliases(finding.vulnerability.aliases)">
+                          <span v-for="alias in resolveVulnAliases(finding.vulnerability.aliases, finding.vulnerability.source)">
                           <b-link style="margin-right:1.0rem" :href="'/vulnerabilities/' + alias.source + '/' + alias.vulnId">{{ alias.vulnId }}</b-link>
                           </span>
                         </b-card-text>
@@ -368,8 +368,8 @@ import common from "../../../shared/common";
               },
               mixins: [permissionsMixin],
               methods: {
-                resolveVulnAliases: function(aliases) {
-                  return common.resolveVulnAliases(this.source, aliases);
+                resolveVulnAliases: function(aliases, vulnSource) {
+                  return common.resolveVulnAliases(vulnSource ? vulnSource : this.source, aliases);
                 },
                 getAnalysis: function() {
                   let queryString = "?project=" + projectUuid + "&component=" + this.finding.component.uuid + "&vulnerability=" + this.finding.vulnerability.uuid;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes a defect where vulnerability aliases would not be displayed when expanding rows in the *Audit Vulnerabilities* table.

<img width="947" alt="Screenshot 2023-07-25 at 23 18 03" src="https://github.com/DependencyTrack/frontend/assets/5693141/1850485f-5b85-4241-8dc8-09c8b0771ae5">﻿﻿

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #556

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
