### PR TITLE
Fix license expression input fields

### DIFF
--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -224,6 +224,7 @@
           author: this.component.author,
           description: this.component.description,
           license: this.selectedLicense,
+          licenseExpression: this.component.licenseExpression,
           licenseUrl: this.component.licenseUrl,
           filename: this.component.filename,
           classifier: this.component.classifier,
@@ -258,6 +259,8 @@
       retrieveLicenses: function() {
         let url = `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_CONCISE}`;
         this.axios.get(url).then((response) => {
+          // Allow for license to be un-selected.
+          this.selectableLicenses.push({value: '', text: ''});
           for (let i = 0; i < response.data.length; i++) {
             let license = response.data[i];
             this.selectableLicenses.push({value: license.licenseId, text: license.name, uuid: license.uuid});

--- a/src/views/portfolio/projects/ProjectAddComponentModal.vue
+++ b/src/views/portfolio/projects/ProjectAddComponentModal.vue
@@ -48,6 +48,10 @@
           <b-input-group-form-select id="component-license-input" required="false"
                                      v-model="selectedLicense" :options="selectableLicenses"
                                      :label="$t('message.license')" :tooltip="$t('message.component_spdx_license_desc')" />
+          <b-input-group-form-input id="component-license-expression" input-group-size="mb-3" type="text" v-model="component.licenseExpression"
+                                    required="false" :label="$t('message.license_expression')" :tooltip="$t('message.component_license_expression_desc')" />
+          <b-input-group-form-input id="component-license-url-input" input-group-size="mb-3" type="text" v-model="component.licenseUrl"
+                                    required="false" :label="$t('message.license_url')" :tooltip="$t('message.component_license_url_desc')" />
           <b-form-group
             id="component-copyright-form-group"
             :label="this.$t('message.copyright')"
@@ -138,6 +142,7 @@
           group: this.component.group,
           description: this.component.description,
           license: this.selectedLicense,
+          licenseExpression: this.component.licenseExpression,
           licenseUrl: this.component.licenseUrl,
           filename: this.component.filename,
           classifier: this.component.classifier,
@@ -167,6 +172,7 @@
           group: null,
           description: null,
           license: null,
+          licenseExpression: null,
           licenseUrl:null,
           filename: null,
           classifier: null,
@@ -186,6 +192,8 @@
       retrieveLicenses: function() {
         let url = `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_CONCISE}`;
         this.axios.get(url).then((response) => {
+          // Allow for license to be un-selected.
+          this.selectableLicenses.push({value: '', text: ''});
           for (let i = 0; i < response.data.length; i++) {
             let license = response.data[i];
             this.selectableLicenses.push({value: license.licenseId, text: license.name});


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As a follow-up to #452, this PR fixes the following issues:

* Expressions typed into the *Component Details* dialog were not sent to the API server
* The license expression input field was missing from the *Add Component* dialog

Also, a previously existing issue that prevented selected licenses from being unselectable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
