### PR TITLE
Quick fix : policy_created message

### DIFF
--- a/src/views/policy/CreatePolicyModal.vue
+++ b/src/views/policy/CreatePolicyModal.vue
@@ -37,7 +37,7 @@
         }).then((response) => {
           this.$root.$emit('bv::hide::modal', 'createPolicyModal');
           this.$emit('refreshTable');
-          this.$toastr.s(this.$t('message.project_created'));
+          this.$toastr.s(this.$t('message.policy_created'));
         }).catch((error) => {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));
         }).finally(() => {


### PR DESCRIPTION
### Description

When new policy is created, it displays message 'Project created' instead of 'Policy created'. Variable being used needs to be updated.

### Addressed Issue

NA

### Additional Details

NA

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
