### PR TITLE
Fix outdated indicator not being displayed in dependency graph

### DIFF
--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -334,11 +334,13 @@ export default {
         let dependencies = [...data];
         if (dependencies.length > 0) {
           for (let dependency of dependencies) {
-            if (dependency && dependency.directDependencies) {
+            if (dependency) {
               let treeNode = treeNodeMap.get(dependency.uuid);
               treeNode.latestVersion = dependency.latestVersion;
-              let jsonObject = JSON.parse(dependency.directDependencies);
-              this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(jsonObject, false, treeNode, dependency.uuid, "COMPONENT"));
+              if (dependency.directDependencies) {
+                let jsonObject = JSON.parse(dependency.directDependencies);
+                this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(jsonObject, false, treeNode, dependency.uuid, "COMPONENT"));
+              }
             }
           }
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes a regression introduced in #455, which caused the "outdated" warning sign to not be displayed in the dependency graph.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
