### PR TITLE
Keep focus when editing Alerts (fixes #421)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -653,6 +653,7 @@
     "notification_level": "Notification level",
     "destination": "Destination",
     "delete_alert": "Delete Alert",
+    "submit": "Submit",
     "limit_to": "Limit To",
     "limit_to_projects": "Limit to projects",
     "include_children": "Include children of projects",

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -122,8 +122,7 @@
                 <b-row class="expanded-row">
                   <b-col sm="6">
                     <b-input-group-form-input id="input-name" :label="$t('message.name')" input-group-size="mb-3"
-                                              required="true" type="text" v-model="name" lazy="true"
-                                              v-debounce:750ms="updateNotificationRule" :debounce-events="'keyup'" />
+                                              required="true" type="text" v-model="name" lazy="true" />
                     <b-form-group>
                       <c-switch id="notificationEnabled" color="primary" v-model="enabled" label v-bind="labelIcon"/>
                       {{ $t('admin.enabled') }}
@@ -136,11 +135,9 @@
                     </b-form-group>
                     <b-input-group-form-input id="input-destination" :label="$t('admin.destination')" input-group-size="mb-3"
                                               :required="(!(this.alert.hasOwnProperty('teams') && this.alert.teams != null && this.alert.teams.length > 0)).toString()"
-                                              type="text" v-model="destination" lazy="true"
-                                              v-debounce:750ms="updateNotificationRule" :debounce-events="'keyup'" />
+                                              type="text" v-model="destination" lazy="true" />
                     <b-input-group-form-input v-if="this.publisherClass === 'org.dependencytrack.notification.publisher.JiraPublisher'" id="input-jira-ticket-type"
-                                              :label="$t('admin.jira_ticket_type')" :required="true" type="text" v-model="jiraTicketType" lazy="true"
-                                              v-debounce:750ms="updateNotificationRule" :debounce-events="'keyup'" />
+                                              :label="$t('admin.jira_ticket_type')" :required="true" type="text" v-model="jiraTicketType" lazy="true" />
                      <b-form-group v-if="this.publisherClass === 'org.dependencytrack.notification.publisher.SendMailPublisher'"
                                    id="teamDestinationList" :label="this.$t('admin.select_team_as_recipient')">
                        <div class="list group">
@@ -197,6 +194,7 @@
                                 v-permission="PERMISSIONS.VIEW_PORTFOLIO" v-on:toggle="limitToVisible = !limitToVisible"
                                 v-if="this.scope === 'PORTFOLIO'" />
                        <b-button variant="outline-danger" @click="deleteNotificationRule">{{ $t('admin.delete_alert') }}</b-button>
+                       <b-button variant="primary" @click="updateNotificationRule">{{ $t('admin.submit') }}</b-button>
                     </div>
                   </b-col>
                   <select-project-modal v-on:selection="updateProjectSelection"/>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

When editing an Alert, the form lost focus after every 750ms. This worsened the user experience because the user had to keep re-selecting the form field to make changes. Instead of auto-saving after every 750ms, the form now has a Submit button and will no longer lose focus unintentionally.

### Addressed Issue
Fixes #421 

### Additional Details
![afbeelding](https://github.com/DependencyTrack/frontend/assets/62144407/f3fa5883-b17f-4eb6-a92f-8e5662c06fba)


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
