### PR TITLE
Backport: Use `touch` instead of `mount` to check whether `config.json` is mounted

### DIFF
--- a/docker/docker-entrypoint.d/30-oidc-configuration.sh
+++ b/docker/docker-entrypoint.d/30-oidc-configuration.sh
@@ -2,22 +2,27 @@
 
 set -e
 
-# Check if config.json is mounted
-if mount | grep '/static/config.json'; then
-  echo "config.json is mounted from host - ENV configuration will be ignored"
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+ME=$(basename $0)
+
+if ! touch ./static/config.json 2>/dev/null; then
+  entrypoint_log "$ME: info: can not modify config.json - ENV configuration will be ignored"
 else
-  # Apply ENV vars to temporary config.json
-  jq '.API_BASE_URL = env.API_BASE_URL
-        | .API_WITH_CREDENTIALS = env.API_WITH_CREDENTIALS 
+  CONFIG=$(jq '.API_BASE_URL = env.API_BASE_URL
+        | .API_WITH_CREDENTIALS = env.API_WITH_CREDENTIALS
         | .OIDC_ISSUER = env.OIDC_ISSUER
         | .OIDC_CLIENT_ID = env.OIDC_CLIENT_ID
         | .OIDC_SCOPE = env.OIDC_SCOPE
         | .OIDC_FLOW = env.OIDC_FLOW
         | .OIDC_LOGIN_BUTTON_TEXT = env.OIDC_LOGIN_BUTTON_TEXT' \
-    ./static/config.json > /tmp/config.json
-
-  # Override default config file
-  mv -f /tmp/config.json ./static/config.json
+    ./static/config.json)
+  echo "${CONFIG}" > ./static/config.json
+  entrypoint_log "$ME: info: effective config: $(echo "${CONFIG}" | jq -c '.')"
 fi
 
 exec "$@"


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Use `touch` instead of `mount` to check whether `config.json` is mounted. In some containerized environments, the `mount` command is not available, which caused the previous check to fail.

Additionally, modify the `config.json` file in place when populating it from environment variables, instead of using a temporary file.

The populated config will be logged by the entrypoint script.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #60
Closes #511
Fixes #513
Closes #514

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

Example output:

```
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-oidc-configuration.sh
30-oidc-configuration.sh: info: effective config: {"API_BASE_URL":null,"API_WITH_CREDENTIALS":null,"OIDC_ISSUER":"foo","OIDC_CLIENT_ID":"bar","OIDC_SCOPE":"openid profile email","OIDC_FLOW":null,"OIDC_LOGIN_BUTTON_TEXT":"baz"}
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
