### PR TITLE
New workflow to generate SBOM with evidences using cdxgen

### DIFF
--- a/.github/workflows/sbom-reachables.yaml
+++ b/.github/workflows/sbom-reachables.yaml
@@ -1,0 +1,24 @@
+name: SBOM Reachables
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cdxgen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.1
+      - name: Run cdxgen
+        run: |
+          npm install -g @cyclonedx/cdxgen
+          cdxgen -p -t js --profile research .
+          mkdir -p bomresults
+          cp bom.json *.slices.json bomresults
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bomresults
+          path: bomresults

--- a/.github/workflows/sbom-reachables.yaml
+++ b/.github/workflows/sbom-reachables.yaml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.1.1
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '21'
       - name: Run cdxgen
         run: |
           npm install -g @cyclonedx/cdxgen


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This adds a new workflow to generate an SBOM with evidences using cdxgen.

Below are some links to a sample execution

Component Evidence
https://github.com/prabhu/frontend/actions/runs/6792045073/job/18464667401#step:4:24

Callstack Evidence
https://github.com/prabhu/frontend/actions/runs/6792045073/job/18464667401#step:4:194

Reachable components
https://github.com/prabhu/frontend/actions/runs/6792045073/job/18464667401#step:4:355

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Publishing a comprehensive SBOM with a `research` profile would help security researchers, and AppSec stay a step ahead with vulnerabilities.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
