### PR TITLE
Add NVD API notice

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -635,6 +635,7 @@
     "vulnsource_alias_sync_enable_tooltip": "Alias data can help in identifying identical vulnerabilities across multiple databases. If the source provides this data, synchronize it with Dependency-Track's database.",
     "vulnsource_nvd_enable": "Enable National Vulnerability Database mirroring",
     "vulnsource_nvd_desc": "The National Vulnerability Database (NVD) is the largest publicly available source of vulnerability intelligence. It is maintained by a group within the National Institute of Standards and Technology (NIST) and builds upon the work of MITRE and others. Vulnerabilities in the NVD are called Common Vulnerabilities and Exposures (CVE). There are over 100,000 CVEs documented in the NVD spanning from the 1990’s to the present.",
+    "vulnsource_nvd_notice": "This product uses data from the NVD API but is not endorsed or certified by the NVD.",
     "vulnsource_nvd_feeds_url": "NVD Feeds URL",
     "vulnsource_github_advisories_enable": "Enable GitHub Advisory mirroring",
     "vulnsource_github_advisories_desc": "GitHub Advisories (GHSA) is a database of CVEs and GitHub-originated security advisories affecting the open source world. Dependency-Track integrates with GHSA by mirroring advisories via GitHub's public GraphQL API. The mirror is refreshed daily, or upon restart of the Dependency-Track instance. A personal access token (PAT) is required in order to authenticate with GitHub, but no scopes need to be assigned to it.",

--- a/src/views/administration/vuln-sources/VulnSourceNvd.vue
+++ b/src/views/administration/vuln-sources/VulnSourceNvd.vue
@@ -12,6 +12,8 @@
       {{$t('admin.vulnsource_nvd_enable')}}
       <hr/>
       {{ $t('admin.vulnsource_nvd_desc') }}
+      <br/><br/>
+      {{ $t('admin.vulnsource_nvd_notice') }}
       <hr/>
       <b-validated-input-group-form-input
         id="nvd-feeds-url"


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds NVD REST API notice.

As per https://nvd.nist.gov/developers/start-here, "[...] services which utilize or access the NVD are asked to display the following notice prominently within the application: 'This product uses data from the NVD API but is not endorsed or certified by the NVD.'".

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
