### PR TITLE
Use VUE_APP_SERVER_URL

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // Relative paths cannot be supported. Research by @nscur0 - https://owasp.slack.com/archives/CTC03GX9S/p1608400149085400
   publicPath: "/",
   devServer: {
-    proxy: { "/api": { target: "http://localhost:8080" } }
+    proxy: { "/api": { target: process.env.VUE_APP_SERVER_URL} }
   },
   configureWebpack: {
     plugins: [


### PR DESCRIPTION
### Description

Make use of the VUE_APP_SERVER_URL from .env.development in the vue config.

### Addressed Issue

Fixes #681

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
