### PR TITLE
Include component count in projects list

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -245,6 +245,12 @@ import ProjectCreateProjectModal from "./ProjectCreateProjectModal";
             sortable: true
           },
           {
+            title: this.$t('message.components'),
+            field: "metrics.components",
+            sortable: true,
+            visible: false
+          },
+          {
             title: this.$t('message.policy_violations'),
             field: "metrics",
             formatter: function (metrics) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // Relative paths cannot be supported. Research by @nscur0 - https://owasp.slack.com/archives/CTC03GX9S/p1608400149085400
   publicPath: "/",
   devServer: {
-    proxy: { "/api": { target: "http://localhost:8080" } }
+    proxy: { "/api": { target: process.env.VUE_APP_SERVER_URL} }
   },
   configureWebpack: {
     plugins: [


### PR DESCRIPTION
### Description

Include project component count on the projects listing page (hidden by default).

### Addressed Issue

Fixes #630

### Additional Details

The other metrics fields have specific code to handle the case where the metrics aren't provided; I don't think that is necessary in this case where just a number is being rendered, not a progress bar. Example with two projects, one with metrics and one without:

<img width="453" alt="image" src="https://github.com/DependencyTrack/frontend/assets/1424497/e6101df9-0d58-4208-bf8b-a253c6215e34">

(The diff accidentally builds on #682)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
