### PR TITLE
Use unique fields for project list metrics columns

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -252,8 +252,9 @@ import ProjectCreateProjectModal from "./ProjectCreateProjectModal";
           },
           {
             title: this.$t('message.policy_violations'),
-            field: "metrics",
-            formatter: function (metrics) {
+            field: "metrics.policyViolationsTotal", // this column uses other fields, but the field id must be unique
+            formatter: function (_, row) {
+              let metrics = row.metrics
               if (typeof metrics === "undefined") {
                 return "-"; // No vulnerability info available
               }
@@ -270,9 +271,10 @@ import ProjectCreateProjectModal from "./ProjectCreateProjectModal";
           },
           {
             title: this.$t('message.vulnerabilities'),
-            field: "metrics",
+            field: "metrics.vulnerabilities", // this column uses other fields, but the field id must be unique
             sortable: false,
-            formatter(metrics, row, index) {
+            formatter(_, row) {
+              let metrics = row.metrics
               if (typeof metrics === "undefined") {
                 return "-"; // No vulnerability info available
               }


### PR DESCRIPTION
### Description

This PR makes the vulnerabilities and policy violations use unique field IDs in the bootstrap table spec. The docs say:

> This field must be unique, or some unknown problems may occur.

The frontend also uses the field id to save which columns the user has marked as visible or not.

### Addressed Issue

Fixes #608
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

Tested with vulnerabilities present and absent, and with policy violations absent or zero. I don't have a project handy that has any policy violations, but the behaviour shouldn't change based on >0 vs absent.

<img width="453" alt="image" src="https://github.com/DependencyTrack/frontend/assets/1424497/865d0512-4b6f-4ae6-972c-57834fcd643c">

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
