### PR TITLE
feat(violations): add current fail, warn, info metrics to footer

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -50,6 +50,55 @@
             </b-col>
           </b-row>
           <chart-policy-violations ref="chartPolicyViolations" chartId="chartPolicyViolations" class="chart-wrapper" style="height:200px;margin-top:40px;" :height="200"></chart-policy-violations>
+          <div slot="footer">
+            <b-row class="text-center">
+              <b-col class="mb-sm-2 mb-0 d-md-down-none">
+                <div class="text-muted">
+                  {{ $t("policy_violation.fails") }}
+                </div>
+                <strong
+                  >{{ failViolations }} ({{ failViolationsPercent }}%)</strong
+                >
+                <b-progress
+                  height="{}"
+                  class="progress-xs mt-2"
+                  :precision="1"
+                  variant="info"
+                  v-bind:value="failViolationsPercent"
+                ></b-progress>
+              </b-col>
+              <b-col class="mb-sm-2 mb-0">
+                <div class="text-muted">
+                  {{ $t("policy_violation.warns") }}
+                </div>
+                <strong
+                  >{{ warnViolations }} ({{ warnViolationsPercent }}%)</strong
+                >
+                <b-progress
+                  height="{}"
+                  class="progress-xs mt-2"
+                  :precision="1"
+                  variant="warning"
+                  v-bind:value="warnViolationsPercent"
+                ></b-progress>
+              </b-col>
+              <b-col class="mb-sm-2 mb-0">
+                <div class="text-muted">
+                  {{ $t("policy_violation.infos") }}
+                </div>
+                <strong
+                  >{{ infoViolations }} ({{ infoViolationsPercent }}%)</strong
+                >
+                <b-progress
+                  height="{}"
+                  class="progress-xs mt-2"
+                  :precision="1"
+                  variant="danger"
+                  v-bind:value="infoViolationsPercent"
+                ></b-progress>
+              </b-col>
+            </b-row>
+          </div>
         </b-card>
       </b-col>
       <b-col sm="6">
@@ -177,6 +226,12 @@
         totalViolations: 0,
         auditedViolations: 0,
         auditedViolationsPercent: 0,
+        failViolations: 0,
+        failViolationsPercent: 0,
+        warnViolations: 0,
+        warnViolationsPercent: 0,
+        infoViolations: 0,
+        infoViolationsPercent: 0,
 
         vulnerabilities: 0,
         suppressed: 0,
@@ -204,6 +259,12 @@
         this.totalViolations = common.valueWithDefault(metric.policyViolationsTotal, "0");
         this.auditedViolations = common.valueWithDefault(metric.policyViolationsAudited, "0");
         this.auditedViolationsPercent = common.calcProgressPercent(this.policyViolationsTotal, this.policyViolationsAudited);
+        this.failViolations = common.valueWithDefault(metric.policyViolationsFail, "0");
+        this.failViolationsPercent = common.calcProgressPercent(this.totalViolations, this.failViolations);
+        this.warnViolations = common.valueWithDefault(metric.policyViolationsWarn, "0");
+        this.warnViolationsPercent = common.calcProgressPercent(this.totalViolations, this.warnViolations);
+        this.infoViolations = common.valueWithDefault(metric.policyViolationsInfo, "0");
+        this.infoViolationsPercent = common.calcProgressPercent(this.totalViolations, this.infoViolations);
 
         this.vulnerabilities = common.valueWithDefault(metric.vulnerabilities, "0");
         this.suppressed = common.valueWithDefault(metric.suppressed, "0");

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -254,11 +254,11 @@
 
         this.totalFindings = common.valueWithDefault(metric.findingsTotal, "0");
         this.auditedFindings = common.valueWithDefault(metric.findingsAudited, "0");
-        this.auditedFindingPercent = common.calcProgressPercent(this.findingsTotal, this.findingsAudited);
+        this.auditedFindingPercent = common.calcProgressPercent(this.totalFindings, this.auditedFindings);
 
         this.totalViolations = common.valueWithDefault(metric.policyViolationsTotal, "0");
         this.auditedViolations = common.valueWithDefault(metric.policyViolationsAudited, "0");
-        this.auditedViolationsPercent = common.calcProgressPercent(this.policyViolationsTotal, this.policyViolationsAudited);
+        this.auditedViolationsPercent = common.calcProgressPercent(this.totalViolations, this.auditedViolations);
         this.failViolations = common.valueWithDefault(metric.policyViolationsFail, "0");
         this.failViolationsPercent = common.calcProgressPercent(this.totalViolations, this.failViolations);
         this.warnViolations = common.valueWithDefault(metric.policyViolationsWarn, "0");


### PR DESCRIPTION
### Description

Add footer to the existing `Policy Violations` card, similar to that of `Portfolio Vulnerabilities` that shows the current metrics for fail, warn and info policy violations.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Displays current metrics to help with usability and clarity.  

Current functionality is quite fiddly to hover-over the chart and get the current policy violation metrics
 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

Example using mocked data

![Screenshot 2024-01-26 at 1 19 42 PM](https://github.com/DependencyTrack/frontend/assets/386277/c525aaeb-86ae-40ee-b0e9-8dde68e93af8)



### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
