### PR TITLE
refactor(dashboard): set progress colors via scss

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -11,21 +11,39 @@ html {
 }
 .severity-critical, .status-failed {
   color: $severity-critical;
+  .progress-bar {
+    background-color: $severity-critical;
+  }
 }
 .severity-high {
   color:$severity-high;
+  .progress-bar {
+    background-color: $severity-high;
+  }
 }
 .severity-medium, .status-warning {
   color: $severity-medium;
+  .progress-bar {
+    background-color: $severity-medium;
+  }
 }
 .severity-low, .status-passed {
   color: $severity-low;
+  .progress-bar {
+    background-color: $severity-low;
+  }
 }
-.severity-info {
+.severity-info, .status-info {
   color: $severity-info;
+  .progress-bar {
+    background-color: $severity-info;
+  }
 }
 .severity-unassigned {
   color: $severity-unassigned;
+  .progress-bar {
+    background-color: $severity-unassigned;
+  }
 }
 // Fixes the width for the bootstrap progress bar in tables
 .table-progress {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -18,22 +18,22 @@
           <b-col class="mb-sm-2 mb-0">
             <div class="text-muted">{{ $t('message.vulnerable_projects') }}</div>
             <strong>{{vulnerableProjects}} ({{vulnerableProjectPercent}}%)</strong>
-            <b-progress height={} class="progress-xs mt-2" :precision="1" variant="success" v-bind:value="vulnerableProjectPercent"></b-progress>
+            <b-progress height={} class="progress-xs mt-2 status-passed" :precision="1" v-bind:value="vulnerableProjectPercent"></b-progress>
           </b-col>
           <b-col class="mb-sm-2 mb-0 d-md-down-none">
             <div class="text-muted">{{ $t('message.violations_audited') }}</div>
             <strong>{{auditedViolations}} ({{auditedViolationsPercent}}%)</strong>
-            <b-progress height={} class="progress-xs mt-2" :precision="1" variant="info" v-bind:value="auditedViolationsPercent"></b-progress>
+            <b-progress height={} class="progress-xs mt-2 status-info" :precision="1" v-bind:value="auditedViolationsPercent"></b-progress>
           </b-col>
           <b-col class="mb-sm-2 mb-0">
             <div class="text-muted">{{ $t('message.vulnerable_components') }}</div>
             <strong>{{vulnerableComponents}} ({{vulnerableComponentPercent}}%)</strong>
-            <b-progress height={} class="progress-xs mt-2" :precision="1" variant="warning" v-bind:value="vulnerableComponentPercent"></b-progress>
+            <b-progress height={} class="progress-xs mt-2 status-warning" :precision="1" v-bind:value="vulnerableComponentPercent"></b-progress>
           </b-col>
           <b-col class="mb-sm-2 mb-0">
             <div class="text-muted">{{ $t('message.findings_audited') }}</div>
             <strong>{{auditedFindings}} ({{auditedFindingPercent}}%)</strong>
-            <b-progress height={} class="progress-xs mt-2" :precision="1" variant="danger" v-bind:value="auditedFindingPercent"></b-progress>
+            <b-progress height={} class="progress-xs mt-2 status-failed" :precision="1" v-bind:value="auditedFindingPercent"></b-progress>
           </b-col>
         </b-row>
       </div>
@@ -53,49 +53,19 @@
           <div slot="footer">
             <b-row class="text-center">
               <b-col class="mb-sm-2 mb-0 d-md-down-none">
-                <div class="text-muted">
-                  {{ $t("policy_violation.fails") }}
-                </div>
-                <strong
-                  >{{ failViolations }} ({{ failViolationsPercent }}%)</strong
-                >
-                <b-progress
-                  height="{}"
-                  class="progress-xs mt-2"
-                  :precision="1"
-                  variant="danger"
-                  v-bind:value="failViolationsPercent"
-                ></b-progress>
+                <div class="text-muted">{{ $t("policy_violation.fails") }}</div>
+                <strong>{{ failViolations }} ({{ failViolationsPercent }}%)</strong>
+                <b-progress height="{}" class="progress-xs mt-2 status-failed" :precision="1" v-bind:value="failViolationsPercent"></b-progress>
               </b-col>
               <b-col class="mb-sm-2 mb-0">
-                <div class="text-muted">
-                  {{ $t("policy_violation.warns") }}
-                </div>
-                <strong
-                  >{{ warnViolations }} ({{ warnViolationsPercent }}%)</strong
-                >
-                <b-progress
-                  height="{}"
-                  class="progress-xs mt-2"
-                  :precision="1"
-                  variant="warning"
-                  v-bind:value="warnViolationsPercent"
-                ></b-progress>
+                <div class="text-muted">{{ $t("policy_violation.warns") }}</div>
+                <strong>{{ warnViolations }} ({{ warnViolationsPercent }}%)</strong>
+                <b-progress height="{}" class="progress-xs mt-2 status-warning" :precision="1" v-bind:value="warnViolationsPercent"></b-progress>
               </b-col>
               <b-col class="mb-sm-2 mb-0">
-                <div class="text-muted">
-                  {{ $t("policy_violation.infos") }}
-                </div>
-                <strong
-                  >{{ infoViolations }} ({{ infoViolationsPercent }}%)</strong
-                >
-                <b-progress
-                  height="{}"
-                  class="progress-xs mt-2"
-                  :precision="1"
-                  variant="info"
-                  v-bind:value="infoViolationsPercent"
-                ></b-progress>
+                <div class="text-muted">{{ $t("policy_violation.infos") }}</div>
+                <strong>{{ infoViolations }} ({{ infoViolationsPercent }}%)</strong>
+                <b-progress height="{}" class="progress-xs mt-2 status-info" :precision="1" v-bind:value="infoViolationsPercent"></b-progress>
               </b-col>
             </b-row>
           </div>


### PR DESCRIPTION
### Description

Set progress colors using SCSS, so that colors are consistent and centrally managed via _variables.scss propertie.

This helps setup future PRs for dashboard footers that will use non-standard bootstrap progress variant colors (ie: severity high which is `orange`)

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
