### PR TITLE
New Subject Prefix Input Box

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -594,6 +594,7 @@
     "enable_bom_spdx": "Enable SPDX",
     "enable_email": "Enable email",
     "email_from_address": "From email address",
+    "email_prefix": "Subject prefix",
     "email_smtp_server": "SMTP server",
     "email_smtp_port": "SMTP server port",
     "email_smtp_username": "SMTP username",

--- a/src/views/administration/configuration/Email.vue
+++ b/src/views/administration/configuration/Email.vue
@@ -101,7 +101,7 @@
         this.updateConfigProperties([
           {groupName: 'email', propertyName: 'smtp.enabled', propertyValue: this.isEmailEnabled},
           {groupName: 'email', propertyName: 'smtp.from.address', propertyValue: this.emailFromAddress},
-          {groupName: 'email', propertyName: 'smtp.prefix', propertyValue: this.emailPrefix},
+          {groupName: 'email', propertyName: 'subject.prefix', propertyValue: this.emailPrefix},
           {groupName: 'email', propertyName: 'smtp.server.hostname', propertyValue: this.emailSmtpServer},
           {groupName: 'email', propertyName: 'smtp.server.port', propertyValue: this.emailSmtpPort},
           {groupName: 'email', propertyName: 'smtp.username', propertyValue: this.emailSmtpUsername},
@@ -112,7 +112,7 @@
           this.updateConfigProperty("email", "smtp.password", this.emailSmtpPassword);
         }
         if (typeof this.emailPrefix == "undefined") {
-          this.updateConfigProperty("email","smtp.prefix", " ");
+          this.updateConfigProperty("email","subject.prefix", " ");
         }
       }
     },
@@ -126,7 +126,7 @@
               this.isEmailEnabled = common.toBoolean(item.propertyValue); break;
             case "smtp.from.address":
               this.emailFromAddress = item.propertyValue; break;
-            case "smtp.prefix":
+            case "subject.prefix":
               this.emailPrefix = item.propertyValue; break;
             case "smtp.server.hostname":
               this.emailSmtpServer = item.propertyValue; break;

--- a/src/views/administration/configuration/Email.vue
+++ b/src/views/administration/configuration/Email.vue
@@ -12,6 +12,14 @@
         lazy="true"
       />
       <b-validated-input-group-form-input
+        id="email-prefix"
+        :label="$t('admin.email_prefix')"
+        input-group-size="mb-3"
+        type="text"
+        v-model="emailPrefix"
+        lazy="true"
+      />
+      <b-validated-input-group-form-input
         id="email-smtp-server"
         :label="$t('admin.email_smtp_server')"
         input-group-size="mb-3"
@@ -79,6 +87,7 @@
       return {
         isEmailEnabled: false,
         emailFromAddress: '',
+        emailPrefix: '',
         emailSmtpServer: '',
         emailSmtpPort: '',
         emailSmtpUsername: '',
@@ -92,6 +101,7 @@
         this.updateConfigProperties([
           {groupName: 'email', propertyName: 'smtp.enabled', propertyValue: this.isEmailEnabled},
           {groupName: 'email', propertyName: 'smtp.from.address', propertyValue: this.emailFromAddress},
+          {groupName: 'email', propertyName: 'smtp.prefix', propertyValue: this.emailPrefix},
           {groupName: 'email', propertyName: 'smtp.server.hostname', propertyValue: this.emailSmtpServer},
           {groupName: 'email', propertyName: 'smtp.server.port', propertyValue: this.emailSmtpPort},
           {groupName: 'email', propertyName: 'smtp.username', propertyValue: this.emailSmtpUsername},
@@ -100,6 +110,9 @@
         ]);
         if (this.emailSmtpPassword !== "HiddenDecryptedPropertyPlaceholder") {
           this.updateConfigProperty("email", "smtp.password", this.emailSmtpPassword);
+        }
+        if (typeof this.emailPrefix == "undefined") {
+          this.updateConfigProperty("email","smtp.prefix", " ");
         }
       }
     },
@@ -113,6 +126,8 @@
               this.isEmailEnabled = common.toBoolean(item.propertyValue); break;
             case "smtp.from.address":
               this.emailFromAddress = item.propertyValue; break;
+            case "smtp.prefix":
+              this.emailPrefix = item.propertyValue; break;
             case "smtp.server.hostname":
               this.emailSmtpServer = item.propertyValue; break;
             case "smtp.server.port":


### PR DESCRIPTION
### Description

- Email Subject Prefix is Hardcoded rightnow `.subject("[Dependency-Track] " + notification.getTitle())`, 
- This is a solution to allow the User to modify the Subject Prefix to its will  `.subject(smtpPrefix + " " + notification.getTitle() )`

This modification would be available in `Administration>Configuration>Email` 
and ` "[Dependency-Track]"` would be the first default value. 

If the User change the Subject Prefix, it will need to press Update button in order to save the changes.
Subject Prefix is **not a required field** so leaving the input box in blank is also an option.

 **_This new feature helps to distinguish between several instances of Dependency-Track, e.g. prod and qual systems._**

### Default value: _[Dependency-Track]_
![image](https://github.com/DependencyTrack/dependency-track/assets/52439101/4aba3cc6-198b-4799-988c-9c2d6a644f0f)
### Modified Value:  _[Dependency-Track TEST ®]_
![image](https://github.com/DependencyTrack/dependency-track/assets/52439101/0ed589d4-8c65-47fe-990f-83c1657f729e)
### Modified Value: " "
![image](https://github.com/DependencyTrack/dependency-track/assets/52439101/129beb2e-f7b0-461e-90b4-5c5d7aa583c9)


This PR depends on its corresponding PR in the **server** repository
https://github.com/DependencyTrack/dependency-track/pull/3422

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
This fixes https://github.com/DependencyTrack/dependency-track/issues/1823
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details 
Check `this.emailPrefix == "undefined"`, so at the moment of update it save` " "` value

```javascript
        if (typeof this.emailPrefix == "undefined") {
          this.updateConfigProperty("email","smtp.prefix", " ");
        }
``` 

This PR is supervised by @lukas-braune.

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly

Signed-off-by: Andres Tito <andres.tito@rohde-schwarz.com>
