### PR TITLE
refactor(project details): improve UX for active/inactive toggle.

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -58,6 +58,7 @@
     "version": "Version",
     "bom_format": "BOM Format",
     "active": "Active",
+    "inactive": "Inactive",
     "name": "Name",
     "published": "Published",
     "cwe": "CWE",

--- a/src/views/portfolio/projects/ProjectDetailsModal.vue
+++ b/src/views/portfolio/projects/ProjectDetailsModal.vue
@@ -41,7 +41,7 @@
           </b-form-group>
           <c-switch id="input-5" class="mx-1" color="primary" v-model="project.active" label
                     :disabled="this.isNotPermitted(PERMISSIONS.PORTFOLIO_MANAGEMENT) || (project.active && this.hasActiveChild(project))" v-bind="labelIcon"
-                    v-b-tooltip.hover :title="$t('message.inactive_active_children')"/> {{$t('message.active')}}
+                    v-b-tooltip.hover :title="$t('message.inactive_active_children')" @change="syncActiveLabel"/> {{projectActiveLabel}}
           <p></p>
           <b-input-group-form-input id="project-uuid" input-group-size="mb-3" type="text" v-model="project.uuid"
                                     lazy="false" required="false" feedback="false" autofocus="false" disabled="true"
@@ -226,6 +226,7 @@
       return {
         readOnlyProjectName: '',
         readOnlyProjectVersion: '',
+        projectActiveLabel: this.project.active ? this.$i18n.t('message.active') : this.$i18n.t('message.inactive'),
         availableClassifiers: [
           { value: 'APPLICATION', text: this.$i18n.t('message.component_application') },
           { value: 'FRAMEWORK', text: this.$i18n.t('message.component_framework') },
@@ -382,6 +383,9 @@
       },
       syncReadOnlyVersionField: function(value) {
         this.readOnlyProjectVersion = value;
+      },
+      syncActiveLabel: function(value) {
+        this.projectActiveLabel = value ? this.$t('message.active') : this.$t('message.inactive')
       },
       updateProject: function() {
         let url = `${this.$api.BASE_URL}/${this.$api.URL_PROJECT}`;


### PR DESCRIPTION
### Description

Improve clarity around project active status and sync label on switch changes


<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Improve the UX around the `Active` / `Inactive` switch under `Project Details`

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
