### PR TITLE
Fix redundant requests to `/api/v1/component` when loading project page

### DIFF
--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -80,8 +80,8 @@ import SeverityProgressBar from "../../components/SeverityProgressBar";
           dataOn: '\u2713',
           dataOff: '\u2715'
         },
-        onlyOutdated: this.onlyOutdated,
-        onlyDirect: this.onlyDirect,
+        onlyOutdated: false,
+        onlyDirect: false,
         columns: [
           {
             field: "state",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes redundant requests to `/api/v1/component` when loading project page.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

`onlyOutdated` and `onlyDirect` were initialized with non-boolean values. Both variables have a watch on them, triggering a refresh of the components table upon change. Both variables are used as model for `c-switch` components, causing their value to transition to `false` immediately, triggering the watches and consequently table refreshes.

This behavior could cause requests to be abandoned before their content was fully consumed, resulting in `EofException`s in the API server.

Abandoned requests are also visible in the Network tab of the browser:

<img width="996" alt="image" src="https://github.com/DependencyTrack/frontend/assets/5693141/c72b601f-b2f5-4c97-998b-829e2f626dad">

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
