### PR TITLE
Fix table column visibility preferences triggering redundant requests

### DIFF
--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -72,8 +72,24 @@ export function getContextPath() {
 }
 
 export function loadUserPreferencesForBootstrapTable(_this, id, columns) {
+  const table = _this.$refs.table;
+  if (!table) {
+    console.error("No table defined in the calling component; Can't apply user preferences");
+    return;
+  }
+
   columns.forEach((column) => {
-    _this.$set(column, "visible", (localStorage && localStorage.getItem(id + "Show" + common.capitalize(column.field)) !== null) ? (localStorage.getItem(id + "Show" + common.capitalize(column.field)) === "true") : column.visible);
+    const isVisible = column.visible;
+    const shouldShow = (localStorage && localStorage.getItem(id + "Show" + common.capitalize(column.field)) !== null)
+      ? (localStorage.getItem(id + "Show" + common.capitalize(column.field)) === "true")
+      : isVisible;
+    if (isVisible !== shouldShow) {
+      if (shouldShow) {
+        table.showColumn(column.field);
+      } else {
+        table.hideColumn(column.field);
+      }
+    }
   })
 }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes table column visibility preferences triggering redundant requests.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

When applying user preferences for column visibility, fields of the bootstrap table were accessed directly. Apparently the bootstrap table has watches on those fields, which caused table contents to be loaded at least twice, instead of once.

This does not happen when using the "official" `table.showColumn` / `table.hideColumn` methods. Switching to those no longer causes duplicate requests.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
