### PR TITLE
feat(project): finding badges including and excluding aliases

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -341,6 +341,11 @@ button:focus {
   margin-left: 0.6em !important;
   color: #21D983 !important;
 }
+.badge-tab-info {
+  border: 1px solid #60768c !important;
+  background-color: $grey-900 !important;
+  color: $notification-info !important;
+}
 .badge-tag {
   color: $primary;
   background-color: transparent;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -44,6 +44,8 @@
     "vulnerable_projects": "Vulnerable Projects",
     "findings": "Findings",
     "total_findings": "Total Findings",
+    "total_findings_including_aliases": "Total Findings (including aliases)",
+    "total_findings_excluding_aliases": "Total Findings (excluding aliases)",
     "findings_audited": "Findings Audited",
     "findings_unaudited": "Findings Unaudited",
     "auditing_progress": "Auditing Progress",

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -131,8 +131,12 @@
         <project-dependency-graph :key="this.uuid" :uuid="this.uuid" :project="this.project" v-on:total="totalDependencyGraphs = $event" />
       </b-tab>
       <b-tab ref="findings" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('findings')">
-        <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.audit_vulnerabilities') }} <b-badge variant="tab-total">{{ totalFindings }}</b-badge></template>
-        <project-findings :key="this.uuid" :uuid="this.uuid" v-on:total="totalFindings = $event" />
+        <template v-slot:title>
+          <i class="fa fa-tasks"></i> {{ $t('message.audit_vulnerabilities') }}
+          <b-badge variant="tab-total" v-b-tooltip.hover :title="$t('message.total_findings_excluding_aliases')">{{ totalFindings }}</b-badge>
+          <b-badge variant="tab-info" v-b-tooltip.hover :title="$t('message.total_findings_including_aliases')">{{ totalFindingsIncludingAliases }}</b-badge>
+        </template>
+        <project-findings :key="this.uuid" :uuid="this.uuid" v-on:total="totalFindingsIncludingAliases = $event" />
       </b-tab>
       <b-tab ref="epss" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('epss')">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.exploit_predictions') }} <b-badge variant="tab-total">{{ totalEpss }}</b-badge></template>
@@ -222,6 +226,7 @@
         totalServices: 0,
         totalDependencyGraphs: 0,
         totalFindings: 0,
+        totalFindingsIncludingAliases: 0,
         totalEpss: 0,
         totalViolations: 0,
         tabIndex: 0
@@ -253,6 +258,7 @@
           this.currentLow = common.valueWithDefault(this.project.metrics.low, 0);
           this.currentUnassigned = common.valueWithDefault(this.project.metrics.unassigned, 0);
           this.currentRiskScore = common.valueWithDefault(this.project.metrics.inheritedRiskScore, 0);
+          this.totalFindings = common.valueWithDefault(this.project.metrics.findingsTotal, 0)
           EventBus.$emit('addCrumb', this.projectLabel);
           this.$title = this.projectLabel;
         });


### PR DESCRIPTION
### Description

It was pointed out in Slack, that the Audit Vulnerabilities was showing a total, inclusive of aliases.

This PR adds two badges, one for total including aliases, another for total excluding aliases.  I have also added some descriptive tooltips

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Clarifies the total badge figure, which previously conflicted with the sum of the 5 vulnerability pie charts

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<img width="1102" alt="Screenshot 2024-02-07 at 7 28 17 PM" src="https://github.com/DependencyTrack/frontend/assets/386277/0b14018c-523d-4093-8833-9cbd5ae2709d">


<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
