### PR TITLE
feat(project): add tooltip to vuln progress bar

### DIFF
--- a/src/views/components/SeverityProgressBar.vue
+++ b/src/views/components/SeverityProgressBar.vue
@@ -5,13 +5,28 @@
     </b-progress>
   </span>
   <span v-else class="progress">
-    <b-progress class="table-progress" :max="vulnerabilities" show-value>
-      <b-progress-bar :value="critical" class="severity-critical-bg"></b-progress-bar>
-      <b-progress-bar :value="high" class="severity-high-bg"></b-progress-bar>
-      <b-progress-bar :value="medium" class="severity-medium-bg"></b-progress-bar>
-      <b-progress-bar :value="low" class="severity-low-bg"></b-progress-bar>
-      <b-progress-bar :value="unassigned" class="severity-unassigned-bg"></b-progress-bar>
-    </b-progress>
+    <span :id="'progressbar' + hoverId" class="table-progress">
+      <b-progress class="table-progress" :max="vulnerabilities" show-value>
+        <b-progress-bar :value="critical" class="severity-critical-bg"></b-progress-bar>
+        <b-progress-bar :value="high" class="severity-high-bg"></b-progress-bar>
+        <b-progress-bar :value="medium" class="severity-medium-bg"></b-progress-bar>
+        <b-progress-bar :value="low" class="severity-low-bg"></b-progress-bar>
+        <b-progress-bar :value="unassigned" class="severity-unassigned-bg"></b-progress-bar>
+      </b-progress>
+    </span>
+    <b-tooltip :target="'progressbar' + hoverId" placement="left" noninteractive>
+      <div style="text-align: left;">
+        <h5>{{$t('message.severity')}}</h5>
+        <p>
+          {{$t('severity.critical')}}: {{ critical }}<br>
+          {{$t('severity.high')}}: {{ high }}<br>
+          {{$t('severity.medium')}}: {{ medium }}<br>
+          {{$t('severity.low')}}: {{ low }}<br>
+          {{$t('severity.unassigned')}}: {{ unassigned }}<br>
+        </p>
+        {{$t('message.total')}}: {{ vulnerabilities }}
+      </div>
+    </b-tooltip>
   </span>
 </template>
 
@@ -23,7 +38,14 @@
       high: Number,
       medium: Number,
       low: Number,
-      unassigned: Number
-    }
+      unassigned: Number,
+      $t: Function,
+    },
+    data() {
+      return {
+        // Workaround for vue references to the progress-bars. Using the ref targets doesn't seem to work.
+        hoverId: Math.random().toString(36),
+      };
+    },
   }
 </script>

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -273,7 +273,7 @@ import ProjectCreateProjectModal from "./ProjectCreateProjectModal";
             title: this.$t('message.vulnerabilities'),
             field: "metrics.vulnerabilities", // this column uses other fields, but the field id must be unique
             sortable: false,
-            formatter(_, row) {
+            formatter: function(_, row) {
               let metrics = row.metrics
               if (typeof metrics === "undefined") {
                 return "-"; // No vulnerability info available
@@ -288,12 +288,13 @@ import ProjectCreateProjectModal from "./ProjectCreateProjectModal";
                   high: metrics.high,
                   medium: metrics.medium,
                   low: metrics.low,
-                  unassigned: metrics.unassigned
+                  unassigned: metrics.unassigned,
+                  $t: this.$t.bind(this),
                 }
               });
               progressBar.$mount();
               return progressBar.$el.outerHTML;
-            }
+            }.bind(this)
           }
         ],
         data: [],


### PR DESCRIPTION
### Description

Add tooltips to the Project List vulnerability progress bar

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Match behavior of Policy Violations progress bar tooltips.  Improves UX for seeing metrics without clicking through.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<img width="327" alt="Screenshot 2024-02-07 at 10 31 35 PM" src="https://github.com/DependencyTrack/frontend/assets/386277/94addb74-ecee-403c-8f23-cff338b9eb32">



<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
