### PR TITLE
Do not append `@<version>` when rendering CPEs in Affected Components view

### DIFF
--- a/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityDetailsModal.vue
@@ -1232,20 +1232,22 @@ export default {
     affectedComponentLabel: function(affectedComponent) {
       let s = affectedComponent.identity;
       if (affectedComponent.versionType === 'RANGE') {
-        s += " ( ";
+        let rangeParts = [];
         if (affectedComponent.versionStartExcluding) {
-          s += ">" + affectedComponent.versionStartExcluding;
+          rangeParts.push(`>${affectedComponent.versionStartExcluding}`);
         } else if (affectedComponent.versionStartIncluding) {
-          s += ">=" + affectedComponent.versionStartIncluding;
+          rangeParts.push(`>=${affectedComponent.versionStartIncluding}`);
         }
         if (affectedComponent.versionEndExcluding) {
-          s += "|<" + affectedComponent.versionEndExcluding;
+          rangeParts.push(`<${affectedComponent.versionEndExcluding}`);
         } else if (affectedComponent.versionEndIncluding) {
-          s += "|<=" + affectedComponent.versionEndIncluding;
+          rangeParts.push(`<=${affectedComponent.versionEndIncluding}`);
         }
-        s += " )";
-      } else if (affectedComponent.versionType === 'EXACT' && !s.includes("@")) {
-        s += "@"+affectedComponent.version;
+        if (rangeParts.length > 0) {
+          s += ` (${rangeParts.join("|")})`;
+        }
+      } else if (affectedComponent.identityType === 'PURL' && affectedComponent.versionType === 'EXACT' && !s.includes("@")) {
+        s += "@" + affectedComponent.version;
       }
       return s;
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Do not append `@<version>` when rendering CPEs in Affected Components view.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #747

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

![Screenshot 2024-02-24 at 10 49 17](https://github.com/DependencyTrack/frontend/assets/5693141/e6ebc85d-4392-439b-881d-64943d7a6ef2)

![Screenshot 2024-02-24 at 11 00 54](https://github.com/DependencyTrack/frontend/assets/5693141/7a2cf258-af8b-4f48-baa5-330d7e691704)

Also cleaned up how ranges are rendered. Previously, ranges with only upper bounds would be rendered as `(|<x.y.z)`, now they're rendered as `(<x.y.z)`.

![Screenshot 2024-02-24 at 11 02 40](https://github.com/DependencyTrack/frontend/assets/5693141/67e6bc58-2506-4a60-9bd6-ffc1073e3252)


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
