### PR TITLE
Adds possibility to limit alerts to tags

### DIFF
--- a/src/views/portfolio/tags/SelectTagModal.vue
+++ b/src/views/portfolio/tags/SelectTagModal.vue
@@ -40,8 +40,15 @@ export default {
   mixins: [permissionsMixin],
   methods: {
     apiUrl: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}/${this.policy.uuid}`;
-      return url;
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}`;
+        if (this.policy) {
+          url = `${url}/policy/${this.policy.uuid}`;
+        }
+
+        if (this.alert) {
+          url = `${url}/rule/${this.alert.uuid}`;
+        }
+        return url;
     },
     refreshTable: function () {
       this.$refs.table.refresh({


### PR DESCRIPTION
### Description
Adds the possibility to select tags in the 'Limit to' section of alerts. This PR is the front part of #3506

### Addressed Issue
Fixes: # 2975

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
