### PR TITLE
Aliases column is not displaying information in Vulnerabilities section

### DIFF
--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -87,9 +87,9 @@ export default {
           field: 'aliases',
           visible: false,
           formatter(value, row, index) {
-            let label = '';
             if (typeof value !== 'undefined') {
-              const aliases = common.resolveVulnAliases(row.source,row.aliases);
+              let label = '';
+              const aliases = common.resolveVulnAliases(row.source, value);
               for (let i = 0; i < aliases.length; i++) {
                 let alias = aliases[i];
                 let url = xssFilters.uriInUnQuotedAttr(
@@ -102,8 +102,8 @@ export default {
                   )}</a>`;
                 if (i < aliases.length - 1) label += '<br/><br/>';
               }
+              return label;
             }
-            return label;
           },
         },
         {

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -87,9 +87,9 @@ export default {
           field: 'aliases',
           visible: false,
           formatter(value, row, index) {
+            let label = '';
             if (typeof value !== 'undefined') {
-              let label = '';
-              const aliases = common.resolveVulnAliases(value);
+              const aliases = common.resolveVulnAliases(row.source,row.aliases);
               for (let i = 0; i < aliases.length; i++) {
                 let alias = aliases[i];
                 let url = xssFilters.uriInUnQuotedAttr(
@@ -102,8 +102,8 @@ export default {
                   )}</a>`;
                 if (i < aliases.length - 1) label += '<br/><br/>';
               }
-              return label;
             }
+            return label;
           },
         },
         {


### PR DESCRIPTION
### Description
Add Neccesary parameter to resolveVulnAliases function
common.resolveVulnALiases needs the vulnerability source and the aliases to deduplicate the list on the Aliases column,

The only parameter added to the function was "value" which do not include neither the source of the current vulnerability or their aliases.

Thats why I am adding row.source and row.aliases to the function.

I discovered that the 'return' statement was located within the condition if(typeof value !== 'undefined'), This created a problem because the function would not return anything for null values. To fix this, I moved the 'return' outside of the condition.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
#765 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
