### PR TITLE
Fix API key rows not being displayed

### DIFF
--- a/src/views/administration/accessmanagement/ApiKeyListGroupItem.vue
+++ b/src/views/administration/accessmanagement/ApiKeyListGroupItem.vue
@@ -57,18 +57,18 @@ export default {
     EditApiKeyCommentModal,
   },
   computed: {
-    keyId: () => {
+    keyId: function () {
       return MurmurHash2(this.apiKey.key).result();
     },
-    comment: () => {
+    comment: function () {
       return this.apiKey.comment ? this.apiKey.comment : 'No comment';
     },
-    createdTimestamp: () => {
+    createdTimestamp: function () {
       return this.apiKey.created
         ? common.formatTimestamp(this.apiKey.created, true)
         : 'N/A';
     },
-    lastUsedTimestamp: () => {
+    lastUsedTimestamp: function () {
       return this.apiKey.lastUsed
         ? common.formatTimestamp(this.apiKey.lastUsed, true)
         : 'N/A';

--- a/src/views/administration/accessmanagement/EditApiKeyCommentModal.vue
+++ b/src/views/administration/accessmanagement/EditApiKeyCommentModal.vue
@@ -50,7 +50,7 @@ export default {
     this.comment = this.apiKey.comment;
   },
   methods: {
-    updateComment: () => {
+    updateComment: function () {
       this.axios
         .post(
           `${this.$api.BASE_URL}/${this.$api.URL_TEAM}/key/${this.apiKey.key}/comment`,
@@ -70,7 +70,7 @@ export default {
           );
         });
     },
-    resetValues: () => {
+    resetValues: function () {
       this.comment = null;
     },
   },


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes API key rows not being displayed.

The keyword `this` is not available when using `() => {}` notation instead of `function() {}`...

This is a regression introduced in #768. Thanks @msymons for spotting it!

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
