### PR TITLE
feat(component): add internal column to component search list view

### DIFF
--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -259,6 +259,16 @@ export default {
           },
         },
         {
+          title: this.$t('message.internal'),
+          field: 'isInternal',
+          sortable: false,
+          align: 'center',
+          class: 'tight',
+          formatter: function (value, row, index) {
+            return value === true ? '<i class="fa fa-check-square-o" />' : '';
+          },
+        },
+        {
           title: this.$t('message.cpe'),
           field: 'cpe',
           sortable: true,


### PR DESCRIPTION
### Description

Add new column called `Internal` to display the component `isInternal` value as a checkbox. 

### Addressed Issue

Previously, the component search list view did not display an indicator of whether it was internal/external.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

![Screenshot 2024-03-13 at 9 59 48 AM](https://github.com/DependencyTrack/frontend/assets/386277/836cc7f4-a84a-4400-8b41-62c5f5e54908)


<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
