### PR TITLE
Transfer copyright from Steve Springett to OWASP Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Note to developers: Textual labels are defined in `src/i18n/locales/{lang}.json`
 
 ## Copyright & License
 
-Dependency-Track is Copyright (c) Steve Springett. All Rights Reserved.
+Dependency-Track is Copyright (c) OWASP Foundation. All Rights Reserved.
 
 Permission to modify and redistribute is granted under the terms of the
 Apache 2.0 license. See the [LICENSE] file for the full license.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Single Page Application for OWASP Dependency-Track",
   "author": "Steve Springett",
   "homepage": "https://dependencytrack.org/",
-  "copyright": "Copyright Steve Springett",
+  "copyright": "Copyright OWASP Foundation",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/views/components/AboutModal.vue
+++ b/src/views/components/AboutModal.vue
@@ -104,7 +104,7 @@
     </b-row>
     <template v-slot:modal-footer="{ cancel }">
       <div class="mx-auto">
-        Copyright &copy; Steve Springett. All Rights Reserved.
+        Copyright &copy; OWASP Foundation. All Rights Reserved.
       </div>
       <b-button size="md" variant="outline-primary" @click="cancel()">{{
         $t('message.close')


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As per [internal discussion](https://owasp.slack.com/archives/C04FL64RPK9/p1710942680826329), this PR transfers copyright from Steve Springett to the OWASP Foundation.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
