### PR TITLE
feat: dynamic policy violation badges based on show suppressed flag

### DIFF
--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -287,31 +287,47 @@
             variant="tab-total"
             v-b-tooltip.hover
             :title="$t('policy_violation.total')"
-            >{{ totalViolations }}</b-badge
+            >{{
+              showSuppressedViolations
+                ? policyViolationsTotal
+                : policyViolationsUnaudited
+            }}</b-badge
           >
           <b-badge
             variant="tab-info"
             v-b-tooltip.hover
             :title="$t('policy_violation.infos')"
-            >{{ infoViolations }}</b-badge
+            >{{
+              showSuppressedViolations
+                ? policyViolationsInfoTotal
+                : policyViolationsInfoUnaudited
+            }}</b-badge
           >
           <b-badge
             variant="tab-warn"
             v-b-tooltip.hover
             :title="$t('policy_violation.warns')"
-            >{{ warnViolations }}</b-badge
+            >{{
+              showSuppressedViolations
+                ? policyViolationsWarnTotal
+                : policyViolationsWarnUnaudited
+            }}</b-badge
           >
           <b-badge
             variant="tab-fail"
             v-b-tooltip.hover
             :title="$t('policy_violation.fails')"
-            >{{ failViolations }}</b-badge
+            >{{
+              showSuppressedViolations
+                ? policyViolationsFailTotal
+                : policyViolationsFailUnaudited
+            }}</b-badge
           >
         </template>
         <project-policy-violations
           :key="this.uuid"
           :uuid="this.uuid"
-          v-on:total="totalViolations = $event"
+          v-on:showSuppressedViolations="showSuppressedViolations = $event"
         />
       </b-tab>
     </b-tabs>
@@ -400,10 +416,15 @@ export default {
       totalFindings: 0,
       totalFindingsIncludingAliases: 0,
       totalEpss: 0,
-      totalViolations: 0,
-      infoViolations: 0,
-      warnViolations: 0,
-      failViolations: 0,
+      showSuppressedViolations: false,
+      policyViolationsTotal: 0,
+      policyViolationsUnaudited: 0,
+      policyViolationsFailTotal: 0,
+      policyViolationsFailUnaudited: 0,
+      policyViolationsWarnTotal: 0,
+      policyViolationsWarnUnaudited: 0,
+      policyViolationsInfoTotal: 0,
+      policyViolationsInfoUnaudited: 0,
       tabIndex: 0,
     };
   },
@@ -458,16 +479,36 @@ export default {
             this.project.metrics.findingsTotal,
             0,
           );
-          this.infoViolations = common.valueWithDefault(
-            this.project.metrics.policyViolationsInfo,
+          this.policyViolationsTotal = common.valueWithDefault(
+            this.project.metrics.policyViolationsTotal,
             0,
           );
-          this.warnViolations = common.valueWithDefault(
-            this.project.metrics.policyViolationsWarn,
+          this.policyViolationsUnaudited = common.valueWithDefault(
+            this.project.metrics.policyViolationsUnaudited,
             0,
           );
-          this.failViolations = common.valueWithDefault(
-            this.project.metrics.policyViolationsFail,
+          this.policyViolationsFailTotal = common.valueWithDefault(
+            this.project.metrics.policyViolationsFailTotal,
+            0,
+          );
+          this.policyViolationsFailUnaudited = common.valueWithDefault(
+            this.project.metrics.policyViolationsFailUnaudited,
+            0,
+          );
+          this.policyViolationsWarnTotal = common.valueWithDefault(
+            this.project.metrics.policyViolationsWarnTotal,
+            0,
+          );
+          this.policyViolationsWarnUnaudited = common.valueWithDefault(
+            this.project.metrics.policyViolationsWarnUnaudited,
+            0,
+          );
+          this.policyViolationsInfoTotal = common.valueWithDefault(
+            this.project.metrics.policyViolationsInfoTotal,
+            0,
+          );
+          this.policyViolationsInfoUnaudited = common.valueWithDefault(
+            this.project.metrics.policyViolationsInfoUnaudited,
             0,
           );
           EventBus.$emit('addCrumb', this.projectLabel);

--- a/src/views/portfolio/projects/ProjectPolicyViolations.vue
+++ b/src/views/portfolio/projects/ProjectPolicyViolations.vue
@@ -438,6 +438,7 @@ export default {
         this.$refs.table.columns,
       );
       this.$emit('total', data.total);
+      this.$emit('showSuppressedViolations', this.showSuppressedViolations);
     },
     initializeTooltips: function () {
       $('[data-toggle="tooltip"]').tooltip({


### PR DESCRIPTION
### Description

Dependent on https://github.com/DependencyTrack/dependency-track/pull/3615

Display the policy violations badge metrics (total, fail, warn, info) based on the showSuppressed flag.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

![Screenshot 2024-04-13 at 9 35 30 AM](https://github.com/DependencyTrack/frontend/assets/386277/08121526-4b02-4b79-a689-bc8ba2f5bc00)
![Screenshot 2024-04-13 at 9 35 34 AM](https://github.com/DependencyTrack/frontend/assets/386277/818310d1-7ade-43fc-85ff-313e179e8c57)



### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
