### PR TITLE
Display EPSS Score And Percentile In Vulnerability Page

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -470,6 +470,7 @@
     "endpoints": "Endpunkte",
     "epss": "EPSS",
     "epss_percentile": "EPSS-Perzentil",
+    "epss_score": "EPSS-Score",
     "exact": "Genau",
     "exploit_predictions": "Exploit-Vorhersagen",
     "exploitable": "Ausnutzbar",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -470,6 +470,7 @@
     "endpoints": "Endpoints",
     "epss": "EPSS",
     "epss_percentile": "EPSS Percentile",
+    "epss_score": "EPSS Score",
     "exact": "Exact",
     "exploit_predictions": "Exploit Predictions",
     "exploitable": "Exploitable",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -470,6 +470,7 @@
     "endpoints": "Puntos finales",
     "epss": "EPS",
     "epss_percentile": "Percentil EPSS",
+    "epss_score": "Puntuación EPSS",
     "exact": "Exacto",
     "exploit_predictions": "Explotar predicciones",
     "exploitable": "Explotable",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -470,6 +470,7 @@
     "endpoints": "Points de terminaison",
     "epss": "EPSS",
     "epss_percentile": "Centile EPSS",
+    "epss_score": "Score EPSS",
     "exact": "Exact",
     "exploit_predictions": "Prédictions d’exploitation",
     "exploitable": "Exploitable",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -470,6 +470,7 @@
     "endpoints": "अंतिमबिंदुओं",
     "epss": "ईपीएसएस",
     "epss_percentile": "ईपीएसएस प्रतिशत",
+    "epss_score": "ईपीएसएस अंक",
     "exact": "एकदम सही",
     "exploit_predictions": "भविष्यवाणियों का फायदा उठाएँ",
     "exploitable": "दोहन",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -470,6 +470,7 @@
     "endpoints": "Endpoint",
     "epss": "EPSS",
     "epss_percentile": "Percentile EPSS",
+    "epss_score": "Punteggio EPSS",
     "exact": "Esatto",
     "exploit_predictions": "Sfruttare le previsioni",
     "exploitable": "Sfruttabile",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -470,6 +470,7 @@
     "endpoints": "エンドポイント",
     "epss": "EPSS",
     "epss_percentile": "EPSSパーセンタイル",
+    "epss_score": "EPSS スコア",
     "exact": "ちょうど",
     "exploit_predictions": "エクスプロイト予測",
     "exploitable": "悪用可能",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -470,6 +470,7 @@
     "endpoints": "Punkty końcowe",
     "epss": "EPSS",
     "epss_percentile": "Percentyl EPSS",
+    "epss_score": "Wynik EPSS",
     "exact": "Dokładny",
     "exploit_predictions": "Przewidywania exploitów",
     "exploitable": "Możliwość wykorzystania",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -470,6 +470,7 @@
     "endpoints": "Pontos finais",
     "epss": "EPSS",
     "epss_percentile": "Percentil EPSS",
+    "epss_score": "Pontuação EPSS",
     "exact": "Exato",
     "exploit_predictions": "Explorar previsões",
     "exploitable": "Explorável",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -470,6 +470,7 @@
     "endpoints": "Pontos finais",
     "epss": "EPSS",
     "epss_percentile": "Percentil EPSS",
+    "epss_score": "Pontuação EPSS",
     "exact": "Exato",
     "exploit_predictions": "Explorar previsões",
     "exploitable": "Explorável",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -470,6 +470,7 @@
     "endpoints": "Конечные точки",
     "epss": "ЭПСС",
     "epss_percentile": "Процентиль EPSS",
+    "epss_score": "Оценка EPSS",
     "exact": "Точный",
     "exploit_predictions": "Эксплуатация прогнозов",
     "exploitable": "Эксплуатационный",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -470,6 +470,7 @@
     "endpoints": "端点",
     "epss": "增强子系统",
     "epss_percentile": "EPSS 百分位数",
+    "epss_score": "EPSS 评分",
     "exact": "精确的",
     "exploit_predictions": "利用预测",
     "exploitable": "可利用",

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -137,6 +137,32 @@
                     v-bind:value="(cvssExploitScore / 10) * 100"
                   ></b-progress>
                 </b-col>
+                <b-col class="mb-sm-2 mb-0 d-sm-down-none">
+                  <div class="text-muted">
+                    {{ $t('message.epss_score') }}
+                  </div>
+                  <strong>{{ epssScore }}</strong>
+                  <b-progress
+                    height="{}"
+                    class="progress-xs mt-2"
+                    :precision="1"
+                    variant="severity-info"
+                    v-bind:value="epssScore * 100"
+                  ></b-progress>
+                </b-col>
+                <b-col class="mb-sm-2 mb-0 d-sm-down-none">
+                  <div class="text-muted">
+                    {{ $t('message.epss_percentile') }}
+                  </div>
+                  <strong>{{ epssPercentile }}</strong>
+                  <b-progress
+                    height="{}"
+                    class="progress-xs mt-2"
+                    :precision="1"
+                    variant="severity-info"
+                    v-bind:value="epssPercentile * 100"
+                  ></b-progress>
+                </b-col>
               </b-row>
             </div>
             <div v-if="owaspRRLikelihoodScore > 0" slot="footer">
@@ -300,6 +326,18 @@ export default {
         this.vulnerability.cvssV3ExploitabilitySubScore
           ? this.vulnerability.cvssV3ExploitabilitySubScore
           : this.vulnerability.cvssV2ExploitabilitySubScore,
+        0,
+      );
+    },
+    epssScore() {
+      return common.valueWithDefault(
+        this.vulnerability.epssScore,
+        0,
+      );
+    },
+    epssPercentile() {
+      return common.valueWithDefault(
+        this.vulnerability.epssPercentile,
         0,
       );
     },

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -330,16 +330,10 @@ export default {
       );
     },
     epssScore() {
-      return common.valueWithDefault(
-        this.vulnerability.epssScore,
-        0,
-      );
+      return common.valueWithDefault(this.vulnerability.epssScore, 0);
     },
     epssPercentile() {
-      return common.valueWithDefault(
-        this.vulnerability.epssPercentile,
-        0,
-      );
+      return common.valueWithDefault(this.vulnerability.epssPercentile, 0);
     },
     owaspRRLikelihoodScore() {
       return common.valueWithDefault(


### PR DESCRIPTION
### Description

Adds the raw EPSS score and percentile numbers to the vulnerability details page, similar to the CVSS Exploit Score and other metrics.

![image](https://github.com/DependencyTrack/frontend/assets/43161107/482350fc-b75a-4bff-9bee-6f3e9c465a20)

### Addressed Issue
Fixes #544 

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
Initially thought of converting both the numbers into percentage by multiplying by 100 for readability (Would have to use .toFixed(2) to avoid JS floating point multiplication precision issue). But kept them as the raw number itself since that's how the [EPSS data by FIRST](https://www.first.org/epss/data_stats) is reported.

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
