### PR TITLE
Force page reload after locale change

### DIFF
--- a/src/views/components/LocalePicker.vue
+++ b/src/views/components/LocalePicker.vue
@@ -36,6 +36,12 @@ export default {
     onLocaleSelected: function (value) {
       localStorage.setItem('Locale', value);
       this.$i18n.locale = value;
+
+      // NB: As of DT v4.11, not all UI elements are updated automatically
+      // when the locale is changed. We force a page reload to work around
+      // this, but it really is a crutch that should be replaced with a proper
+      // solution in the future.
+      this.$router.go(0);
     },
     localeToFlag: function (locale) {
       // Largely taken from wojtekmaj/country-code-to-flag-emoji. Adopted to be able to deal with locale codes as inputs.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Forces page reload after locale change.

This is necessary because not all UI elements are updated automatically when the locale is changed. In order to avoid mixed i18n, or having users do the refresh themselves, we do it automatically for now.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
