### PR TITLE
Restrict Height Of Project Versions Dropdown

### DIFF
--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -542,4 +542,8 @@ export default {
 .badge {
   margin-right: 0.4rem;
 }
+.dropdown-menu {
+  max-height: 30rem;
+  overflow-y: auto;
+}
 </style>


### PR DESCRIPTION
### Description
If a project has many versions, the versions dropdown should be scrollable such that the user can view and select any desired version.

**Demo Video**

https://github.com/DependencyTrack/frontend/assets/43161107/682612be-5677-498e-ad3d-ccd51031a8d1



### Addressed Issue
Fixes #809 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
The `.dropdown-menu` class was referenced in the `<ul>` but not defined, so decided to use that class itself.


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
