### PR TITLE
Backport: Bind i18n Object To SeverityProgressBar Props

### DIFF
--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -330,7 +330,7 @@ export default {
           field: 'metrics',
           sortable: false,
           visible: false,
-          formatter(metrics, row, index) {
+          formatter: function (metrics, row, index) {
             if (typeof metrics === 'undefined') {
               return '-'; // No vulnerability info available
             }
@@ -345,11 +345,12 @@ export default {
                 medium: metrics.medium,
                 low: metrics.low,
                 unassigned: metrics.unassigned,
+                $t: this.$t.bind(this),
               },
             });
             progressBar.$mount();
             return progressBar.$el.outerHTML;
-          },
+          }.bind(this),
         },
       ],
       data: [],

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -275,7 +275,7 @@ export default {
           title: this.$t('message.vulnerabilities'),
           field: 'metrics',
           sortable: false,
-          formatter(metrics, row, index) {
+          formatter: function (metrics, row, index) {
             if (typeof metrics === 'undefined') {
               return '-'; // No vulnerability info available
             }
@@ -290,11 +290,12 @@ export default {
                 medium: metrics.medium,
                 low: metrics.low,
                 unassigned: metrics.unassigned,
+                $t: this.$t.bind(this),
               },
             });
             progressBar.$mount();
             return progressBar.$el.outerHTML;
-          },
+          }.bind(this),
         },
       ],
       data: [],

--- a/src/views/portfolio/projects/ProjectServices.vue
+++ b/src/views/portfolio/projects/ProjectServices.vue
@@ -82,7 +82,7 @@ export default {
           title: this.$t('message.vulnerabilities'),
           field: 'metrics',
           sortable: false,
-          formatter(metrics, row, index) {
+          formatter: function (metrics, row, index) {
             if (typeof metrics === 'undefined') {
               return '-'; // No vulnerability info available
             }
@@ -97,11 +97,12 @@ export default {
                 medium: metrics.medium,
                 low: metrics.low,
                 unassigned: metrics.unassigned,
+                $t: this.$t.bind(this),
               },
             });
             progressBar.$mount();
             return progressBar.$el.outerHTML;
-          },
+          }.bind(this),
         },
       ],
       data: [],


### PR DESCRIPTION
### Description

When instantiating the `SeverityProgressBar` ComponentClass, the `$t` prop for `i18n` should be passed to it, so that the messages in the tooltip of the progress bar are rendered.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

**Screenshot of result:**

![image](https://github.com/DependencyTrack/frontend/assets/43161107/99762c66-4452-475c-86c8-dad325e22b26)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #867
Backports #871

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

I (@aravindparappil46) noticed that it was working fine in `ProjectList`, so referred how it was done there and replicated the same where ever `SeverityProgressBar` is used

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
