### PR TITLE
🚧 WIP: Display Project Tags In Vulnerability Audit Page

### DIFF
--- a/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
+++ b/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
@@ -597,6 +597,33 @@ export default {
           },
         },
         {
+          title: this.$t('message.tags'),
+          field: 'component.tags',
+          sortable: false,
+          visible: false,
+          routerFunc: () => this.$router,
+          formatter(value, row, index) {
+            const router = this.routerFunc();
+            const tags = row.component.tags;
+            let tag_string = '';
+            if (tags) {
+              tag_string =
+                  tags.slice(0, 2)
+                  .map((tag) => common.formatProjectTagLabel(router, tag))
+                  .join(' ') || '';
+              if (tags.length > 2) {
+                tag_string += ` <span class="d-none">`;
+                tag_string += tags.slice(2)
+                  ?.map((tag) => common.formatProjectTagLabel(router, tag))
+                  .join(' ');
+                tag_string += `</span>`;
+                tag_string += `<a href="#" title="show all tags" class="badge badge-tag" onclick="this.previousElementSibling.classList.toggle('d-none')">…</a>`;
+              }
+            }
+            return tag_string;
+          },
+        },
+        {
           title: this.$t('message.component'),
           field: 'component.name',
           sortable: true,


### PR DESCRIPTION
> ⚠️ **NOTE**: This is a **Draft PR**. Need help figuring out how to filter Findings by tags

### Description
Adds a new column "Tags" (hidden by default, can be enabled within the column-chooser) which displays the corresponding project's tags 
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->
![image](https://github.com/DependencyTrack/frontend/assets/43161107/6ef166d9-fbd1-44b0-9371-f57ea07f3167)

### Addressed Issue
Partially addresses #849 
Have to figure out how to filter by tags.
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
The API Server PR is https://github.com/DependencyTrack/dependency-track/pull/3797

Currently, it just populates the `tags` field to the `Finding` response. 

**Help Needed:**
Need assistance figuring out how to filter Findings by tags (filtering will be done by the API Server and the UI just needs to construct the `/findings` URL with a "tags" query param.

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
