### PR TITLE
Sort Components Vulnerabilities by Severity or CWE

### DIFF
--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -81,7 +81,7 @@ export default {
         {
           title: this.$t('message.cwe'),
           field: 'cwes',
-          sortable: false,
+          sortable: true,
           formatter(value, row, index) {
             if (typeof value !== 'undefined') {
               let s = '';
@@ -99,7 +99,7 @@ export default {
         {
           title: this.$t('message.severity'),
           field: 'severity',
-          sortable: false,
+          sortable: true,
           formatter(value, row, index) {
             if (typeof value !== 'undefined') {
               return common.formatSeverityLabel(value);


### PR DESCRIPTION
### Description

Toggle the `sortable` flag for columns "Severity" and "CWE" as the API server [supports sorting since v4.11](https://github.com/DependencyTrack/dependency-track/issues/708#issuecomment-2081583356).

### Addressed Issue

Resolves DependencyTrack/dependency-track#708

> No sorting behavior exists in the Components' Vulnerability tab on the Severity, like in the Projects tab.

### Additional Details


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
