### PR TITLE
Add ability to test notification publishers

### DIFF
--- a/src/views/administration/configuration/EmailTestConfigurationModal.vue
+++ b/src/views/administration/configuration/EmailTestConfigurationModal.vue
@@ -47,7 +47,7 @@ export default {
   },
   methods: {
     testConfiguration: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/smtp`;
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/email`;
       const params = new URLSearchParams();
       params.append('destination', this.emailAddress);
       this.axios

--- a/src/views/administration/configuration/EmailTestConfigurationModal.vue
+++ b/src/views/administration/configuration/EmailTestConfigurationModal.vue
@@ -47,7 +47,7 @@ export default {
   },
   methods: {
     testConfiguration: function () {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/email`;
+      let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/smtp`;
       const params = new URLSearchParams();
       params.append('destination', this.emailAddress);
       this.axios

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -208,7 +208,7 @@ export default {
                       </div>
                     </b-form-group>
                     <div style="text-align:right">
-                      <b-button variant="primary" @click="testNotification">{{ $t('admin.perform_test') }}</b-button>
+                      <b-button variant="outline-primary" @click="testNotification">{{ $t('admin.perform_test') }}</b-button>
                       <b-toggleable-display-button variant="outline-primary" :label="$t('admin.limit_to')"
                                 v-permission="PERMISSIONS.VIEW_PORTFOLIO" v-on:toggle="limitToVisible = !limitToVisible"
                                 v-if="this.scope === 'PORTFOLIO'" />

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -208,6 +208,7 @@ export default {
                       </div>
                     </b-form-group>
                     <div style="text-align:right">
+                      <b-button variant="primary" @click="testNotification">{{ $t('admin.perform_test') }}</b-button>
                       <b-toggleable-display-button variant="outline-primary" :label="$t('admin.limit_to')"
                                 v-permission="PERMISSIONS.VIEW_PORTFOLIO" v-on:toggle="limitToVisible = !limitToVisible"
                                 v-if="this.scope === 'PORTFOLIO'" />
@@ -390,6 +391,27 @@ export default {
                     }
                     this.projects = p;
                     this.$toastr.s(this.$t('message.updated'));
+                  })
+                  .catch((error) => {
+                    this.$toastr.w(this.$t('condition.unsuccessful_action'));
+                  });
+              },
+              testNotification: function () {
+                let publisherName = row.publisher.name;
+                let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/${publisherName.toLowerCase().replace(/ /g, '_')}`;
+
+                let params = new URLSearchParams();
+                params.append('destination', this.destination);
+
+                this.axios
+                  .post(url, params, {
+                    headers: {
+                      'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                  })
+                  .then((response) => {
+                    this.alert = response.data;
+                    this.$toastr.s(this.$t('admin.test_notification_queued'));
                   })
                   .catch((error) => {
                     this.$toastr.w(this.$t('condition.unsuccessful_action'));

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -397,8 +397,7 @@ export default {
                   });
               },
               testNotification: function () {
-                let publisherName = row.publisher.name;
-                let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/${publisherName.toLowerCase().replace(/ /g, '_')}`;
+                let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_PUBLISHER}/test/${this.uuid}`;
 
                 let params = new URLSearchParams();
                 params.append('destination', this.destination);


### PR DESCRIPTION
### Description
Add a button to the notifications settings to test the publisher.

Back-end implementation: https://github.com/DependencyTrack/dependency-track/pull/3983
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
https://github.com/DependencyTrack/dependency-track/issues/2924

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
