### PR TITLE
Remove "Enable SVG Badge support (unauthenticated)" checkbox in favor of authenticated badge API

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Überschreiben der Standardvorlage aktivieren",
     "enable_email": "E-Mail aktivieren",
     "enable_index_consistency_check": "Regelmäßige Konsistenzprüfungen aktivieren",
-    "enable_svg_badge": "SVG-Badge-Unterstützung aktivieren (nicht authentifiziert)",
     "enabled": "Aktiviert",
     "enabled_for_tags": "Aktiviert für Tags",
     "experimental": "Experimentell",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Enable default template override",
     "enable_email": "Enable email",
     "enable_index_consistency_check": "Enable periodic consistency check",
-    "enable_svg_badge": "Enable SVG badge support (unauthenticated)",
     "enabled": "Enabled",
     "enabled_for_tags": "Enabled for tags",
     "experimental": "Experimental",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Habilitar anulación de plantilla predeterminada",
     "enable_email": "Habilitar correo electrónico",
     "enable_index_consistency_check": "Habilitar la verificación periódica de coherencia",
-    "enable_svg_badge": "Habilitar la compatibilidad con insignias SVG (sin autenticar)",
     "enabled": "Activado",
     "enabled_for_tags": "Habilitado para etiquetas",
     "experimental": "Experimental",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Activer le remplacement du modèle par défaut",
     "enable_email": "Activer l'envoi de courriels",
     "enable_index_consistency_check": "Activer le contrôle de cohérence périodique",
-    "enable_svg_badge": "Activer la prise en charge des badges SVG (non authentifiés)",
     "enabled": "Activé",
     "enabled_for_tags": "Activé pour les balises",
     "experimental": "Expérimental",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "डिफ़ॉल्ट टेम्पलेट ओवरराइड सक्षम करें",
     "enable_email": "ईमेल सक्षम करें",
     "enable_index_consistency_check": "आवधिक संगतता जांच सक्षम करें",
-    "enable_svg_badge": "SVG बैज समर्थन सक्षम करें (अप्रमाणित)",
     "enabled": "सक्रिय",
     "enabled_for_tags": "टैग के लिए सक्षम",
     "experimental": "प्रयोगात्मक",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Abilita l'override del modello predefinito",
     "enable_email": "Abilita e-mail",
     "enable_index_consistency_check": "Abilita il controllo periodico della coerenza",
-    "enable_svg_badge": "Abilita il supporto del badge SVG (non autenticato)",
     "enabled": "Abilitato",
     "enabled_for_tags": "Abilitato per i tag",
     "experimental": "Sperimentale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "デフォルトのテンプレートのオーバーライドを有効にする",
     "enable_email": "メールを有効にする",
     "enable_index_consistency_check": "定期的な整合性チェックを有効にする",
-    "enable_svg_badge": "SVG バッジのサポートを有効にする (認証なし)",
     "enabled": "有効",
     "enabled_for_tags": "タグに対して有効化",
     "experimental": "実験的",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Włącz domyślne zastąpienie szablonu",
     "enable_email": "Włącz pocztę e-mail",
     "enable_index_consistency_check": "Włącz okresową kontrolę spójności",
-    "enable_svg_badge": "Włącz obsługę plakietek SVG (nieuwierzytelnione)",
     "enabled": "Włączony",
     "enabled_for_tags": "Włączono dla tagów",
     "experimental": "Eksperymentalny",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Habilitar substituição de modelo padrão",
     "enable_email": "Ativar e-mail",
     "enable_index_consistency_check": "Habilitar verificação periódica de consistência",
-    "enable_svg_badge": "Ativar suporte para emblema SVG (não autenticado)",
     "enabled": "Habilitado",
     "enabled_for_tags": "Ativado para tags",
     "experimental": "Experimental",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Habilitar substituição de modelo padrão",
     "enable_email": "Ativar e-mail",
     "enable_index_consistency_check": "Habilitar verificação periódica de consistência",
-    "enable_svg_badge": "Ativar suporte para emblema SVG (não autenticado)",
     "enabled": "Habilitado",
     "enabled_for_tags": "Ativado para tags",
     "experimental": "Experimental",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Включить переопределение шаблона по умолчанию",
     "enable_email": "Включить электронную почту",
     "enable_index_consistency_check": "Включить периодическую проверку согласованности",
-    "enable_svg_badge": "Включить поддержку значков SVG (без аутентификации)",
     "enabled": "Включено",
     "enabled_for_tags": "Включено для тегов",
     "experimental": "Экспериментальный",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "Увімкнути заміну шаблону за замовчуванням",
     "enable_email": "Увімкнути електронну пошту",
     "enable_index_consistency_check": "Увімкнути періодичну перевірку узгодженості",
-    "enable_svg_badge": "Увімкнути підтримку значка SVG (не автентифіковано)",
     "enabled": "Увімкнено",
     "enabled_for_tags": "Увімкнено для тегів",
     "experimental": "Експериментальний",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -96,7 +96,6 @@
     "enable_default_template_override": "启用默认模板覆盖",
     "enable_email": "启用电子邮件",
     "enable_index_consistency_check": "启用定期一致性检查",
-    "enable_svg_badge": "启用 SVG 徽章支持（未经身份验证）",
     "enabled": "已启用",
     "enabled_for_tags": "为标签启用",
     "experimental": "实验性的",

--- a/src/views/administration/configuration/General.vue
+++ b/src/views/administration/configuration/General.vue
@@ -10,13 +10,6 @@
         v-model="baseUrl"
         tooltip="This URL is used to construct links back to Dependency-Track from external systems."
       />
-      <c-switch
-        id="isBadgesEnabled"
-        color="primary"
-        v-model="isBadgesEnabled"
-        label
-        v-bind="labelIcon"
-      />{{ $t('admin.enable_svg_badge') }}
     </b-card-body>
     <b-card-footer>
       <b-button variant="outline-primary" class="px-4" @click="saveChanges">{{
@@ -27,10 +20,8 @@
 </template>
 
 <script>
-import { Switch as cSwitch } from '@coreui/vue';
 import { ValidationObserver } from 'vee-validate';
 import BValidatedInputGroupFormInput from '../../../forms/BValidatedInputGroupFormInput';
-import common from '../../../shared/common';
 import configPropertyMixin from '../mixins/configPropertyMixin';
 
 export default {
@@ -39,18 +30,12 @@ export default {
     header: String,
   },
   components: {
-    cSwitch,
     ValidationObserver,
     BValidatedInputGroupFormInput,
   },
   data() {
     return {
       baseUrl: '',
-      isBadgesEnabled: false,
-      labelIcon: {
-        dataOn: '\u2713',
-        dataOff: '\u2715',
-      },
     };
   },
   methods: {
@@ -60,11 +45,6 @@ export default {
           groupName: 'general',
           propertyName: 'base.url',
           propertyValue: this.baseUrl,
-        },
-        {
-          groupName: 'general',
-          propertyName: 'badge.enabled',
-          propertyValue: this.isBadgesEnabled,
         },
       ]);
     },
@@ -79,9 +59,6 @@ export default {
         switch (item.propertyName) {
           case 'base.url':
             this.baseUrl = item.propertyValue;
-            break;
-          case 'badge.enabled':
-            this.isBadgesEnabled = common.toBoolean(item.propertyValue);
             break;
         }
       }


### PR DESCRIPTION
Remove frontend elements for this switch, as Badges API get authenticated access.

Downstream change of
https://github.com/DependencyTrack/dependency-track/pull/4059

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
