### PR TITLE
State should now also in not Snapshot version saved

### DIFF
--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -202,29 +202,26 @@ export default {
   mounted() {
     if (this.$dtrack && this.$dtrack.version.includes('SNAPSHOT')) {
       this.$root.$emit('bv::show::modal', 'snapshotModal');
-
-      this.isSidebarMinimized =
-        localStorage && localStorage.getItem('isSidebarMinimized') !== null
-          ? localStorage.getItem('isSidebarMinimized') === 'true'
-          : false;
-      const sidebar = document.body;
-      if (sidebar) {
-        if (this.isSidebarMinimized) {
-          sidebar.classList.add('sidebar-minimized');
-        } else {
-          sidebar.classList.remove('sidebar-minimized');
-        }
-      }
-      this.$nextTick(() => {
-        const sidebarMinimizer = this.$el.querySelector('.sidebar-minimizer');
-        if (sidebarMinimizer) {
-          sidebarMinimizer.addEventListener(
-            'click',
-            this.handleMinimizedUpdate,
-          );
-        }
-      });
     }
+
+    this.isSidebarMinimized =
+      localStorage && localStorage.getItem('isSidebarMinimized') !== null
+        ? localStorage.getItem('isSidebarMinimized') === 'true'
+        : false;
+    const sidebar = document.body;
+    if (sidebar) {
+      if (this.isSidebarMinimized) {
+        sidebar.classList.add('sidebar-minimized');
+      } else {
+        sidebar.classList.remove('sidebar-minimized');
+      }
+    }
+    this.$nextTick(() => {
+      const sidebarMinimizer = this.$el.querySelector('.sidebar-minimizer');
+      if (sidebarMinimizer) {
+        sidebarMinimizer.addEventListener('click', this.handleMinimizedUpdate);
+      }
+    });
   },
   computed: {
     name() {


### PR DESCRIPTION
State before was only in Snapshot version saved/loaded in/from local storage.

### Addressed Issue

Fixes #1031

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
N/A
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
