### PR TITLE
Fix: "Add Version" Create Button Should Be Inactive Until Version Provided

### DIFF
--- a/src/views/portfolio/projects/ProjectAddVersionModal.vue
+++ b/src/views/portfolio/projects/ProjectAddVersionModal.vue
@@ -15,7 +15,13 @@
           label-for="input-1"
           label-class="required"
         >
-          <b-form-input id="input-1" v-model="version" class="required" trim />
+          <b-form-input
+            id="input-1"
+            v-model="version"
+            class="required"
+            trim
+            required
+          />
         </b-form-group>
       </b-col>
       <b-col cols="auto">
@@ -108,9 +114,13 @@
       <b-button size="md" variant="secondary" @click="cancel()">{{
         $t('message.cancel')
       }}</b-button>
-      <b-button size="md" variant="primary" @click="createVersion()">{{
-        $t('message.create')
-      }}</b-button>
+      <b-button
+        size="md"
+        variant="primary"
+        :disabled="isSubmitButtonDisabled"
+        @click="createVersion()"
+        >{{ $t('message.create') }}</b-button
+      >
     </template>
   </b-modal>
 </template>
@@ -136,6 +146,20 @@ export default {
       includePolicyViolations: true,
       makeCloneLatest: false,
     };
+  },
+  computed: {
+    isSubmitButtonDisabled() {
+      const versionInputValue = this.version;
+      if (versionInputValue) {
+        /**
+         * * ideally we would apply the check with the input value trimmed, however, since we are already using 'trim' prop on the input value.
+         * * trimming the value here is not required.
+         */
+        return versionInputValue.length === 0;
+      }
+
+      return true;
+    },
   },
   methods: {
     createVersion: function () {


### PR DESCRIPTION

### Description

I have added a fix to keep the create button inactive until a value is provided in the version input field. This is to improve the form's UX and prevent invalid submissions.

### Addressed Issue

Fixes #995 

### Additional Details

##### Create button disabled when version field is empty
![add-version-disable](https://github.com/user-attachments/assets/fa0642bb-8dad-4a6f-b460-0000acbb158d)


##### Create button enabled when version field is empty
![add-version-enable](https://github.com/user-attachments/assets/b782750f-8d7f-461a-b6b7-cbe69bd1e8c2)


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
