### PR TITLE
Backport: Fix: "Add Version" Create Button Should Be Inactive Until Version Provided

### DIFF
--- a/src/views/portfolio/projects/ProjectAddVersionModal.vue
+++ b/src/views/portfolio/projects/ProjectAddVersionModal.vue
@@ -15,7 +15,13 @@
           label-for="input-1"
           label-class="required"
         >
-          <b-form-input id="input-1" v-model="version" class="required" trim />
+          <b-form-input
+            id="input-1"
+            v-model="version"
+            class="required"
+            trim
+            required
+          />
         </b-form-group>
       </b-col>
       <b-col cols="auto">
@@ -108,9 +114,13 @@
       <b-button size="md" variant="secondary" @click="cancel()">{{
         $t('message.cancel')
       }}</b-button>
-      <b-button size="md" variant="primary" @click="createVersion()">{{
-        $t('message.create')
-      }}</b-button>
+      <b-button
+        size="md"
+        variant="primary"
+        :disabled="isSubmitButtonDisabled"
+        @click="createVersion()"
+        >{{ $t('message.create') }}</b-button
+      >
     </template>
   </b-modal>
 </template>
@@ -136,6 +146,20 @@ export default {
       includePolicyViolations: true,
       makeCloneLatest: false,
     };
+  },
+  computed: {
+    isSubmitButtonDisabled() {
+      const versionInputValue = this.version;
+      if (versionInputValue) {
+        /**
+         * * ideally we would apply the check with the input value trimmed, however, since we are already using 'trim' prop on the input value.
+         * * trimming the value here is not required.
+         */
+        return versionInputValue.length === 0;
+      }
+
+      return true;
+    },
   },
   methods: {
     createVersion: function () {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fix: "Add Version" Create Button Should Be Inactive Until Version Provided.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/frontend/issues/995
Backports https://github.com/DependencyTrack/frontend/pull/1039

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
