### PR TITLE
Issue 4218

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -876,7 +876,8 @@
     "is": "is",
     "is_not": "is not",
     "matches": "matches",
-    "no_match": "does not match"
+    "no_match": "does not match",
+    "not_present": "not present"
   },
   "policy_violation": {
     "fails": "Violation Failures",

--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -249,6 +249,10 @@ export default {
       ],
       regexOperators: [
         { value: 'MATCHES', text: this.$t('operator.matches') },
+        { value: 'NO_MATCH', text: this.$t('operator.no_match') },
+      ],
+      regexOperatorsCpePurl: [
+        { value: 'MATCHES', text: this.$t('operator.matches') },
         { value: 'NOT_PRESENT', text: this.$t('operator.not_present') },
         { value: 'NO_MATCH', text: this.$t('operator.no_match') },
       ],
@@ -365,10 +369,10 @@ export default {
           this.retrieveLicenseGroups();
           break;
         case 'PACKAGE_URL':
-          this.operators = this.regexOperators;
+          this.operators = this.regexOperatorsCpePurl;
           break;
         case 'CPE':
-          this.operators = this.regexOperators;
+          this.operators = this.regexOperatorsCpePurl;
           break;
         case 'SWID_TAGID':
           this.operators = this.regexOperators;

--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -39,6 +39,8 @@
           v-else-if="
             subject !== 'COORDINATES' &&
             subject !== 'VERSION_DISTANCE' &&
+            subject !== 'CPE' &&
+            subject !== 'PACKAGE_URL' &&
             !isSubjectSelectable
           "
           id="input-value"
@@ -50,6 +52,32 @@
           :tooltip="valueInputTooltip()"
           :debounce-events="'keyup'"
         />
+
+        <b-input-group-form-input
+          v-else-if="
+            (subject === 'CPE' && operator !== 'NOT_PRESENT') ||
+            (subject === 'PACKAGE_URL' && operator !== 'NOT_PRESENT')
+          "
+          id="input-value"
+          required="true"
+          type="text"
+          v-model="value"
+          lazy="true"
+          v-debounce:750ms="saveCondition"
+          :tooltip="valueInputTooltip()"
+          :debounce-events="'keyup'"
+        />
+
+        <template
+          v-else-if="
+            (subject === 'CPE' && operator === 'NOT_PRESENT') ||
+            (subject === 'PACKAGE_URL' && operator === 'NOT_PRESENT')
+          "
+        >
+          <div style="display: none">
+            {{ saveCondition() }}
+          </div>
+        </template>
 
         <b-input-group v-else-if="subject === 'COORDINATES'">
           <b-form-input
@@ -221,6 +249,7 @@ export default {
       ],
       regexOperators: [
         { value: 'MATCHES', text: this.$t('operator.matches') },
+        { value: 'NOT_PRESENT', text: this.$t('operator.not_present') },
         { value: 'NO_MATCH', text: this.$t('operator.no_match') },
       ],
       numericOperators: [
@@ -418,7 +447,15 @@ export default {
     },
     saveCondition: function () {
       let dynamicValue = this.createDynamicValue();
-      if (!this.subject || !this.operator || !dynamicValue) {
+      if (
+        !this.subject ||
+        !this.operator ||
+        (!dynamicValue &&
+          !(
+            (this.subject === 'CPE' && this.operator === 'NOT_PRESENT') ||
+            (this.subject === 'PACKAGE_URL' && this.operator === 'NOT_PRESENT')
+          ))
+      ) {
         return;
       }
       if (this.uuid) {
@@ -428,7 +465,8 @@ export default {
             uuid: this.uuid,
             subject: this.subject,
             operator: this.subject === 'COMPONENT_HASH' ? 'IS' : this.operator,
-            value: dynamicValue,
+            value:
+              this.operator === 'NOT_PRESENT' ? 'NOT_PRESENT' : dynamicValue,
           })
           .then((response) => {
             this.uuid = response.data.uuid;
@@ -446,7 +484,8 @@ export default {
           .put(url, {
             subject: this.subject,
             operator: this.subject === 'COMPONENT_HASH' ? 'IS' : this.operator,
-            value: dynamicValue,
+            value:
+              this.operator === 'NOT_PRESENT' ? 'NOT_PRESENT' : dynamicValue,
           })
           .then((response) => {
             this.uuid = response.data.uuid;


### PR DESCRIPTION
### Description
New operator `NOT_PRESENT`, used with `CPE` or `PURL` to verify if the value was present.

When CPE/PURL is selected with `NOT_PRESENT` operator, the input field is removed and the policy is automatically saved.
I added a new operator list for `CPE` and `PURL` as `NOT_PRESENT` is not needed by `SWID_TAG` and `COORDINATES`
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
https://github.com/DependencyTrack/dependency-track/issues/4218
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
