### PR TITLE
docker: fix ipv6 listening

### DIFF
--- a/docker/docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+++ b/docker/docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
@@ -13,7 +13,7 @@ entrypoint_log() {
 }
 
 ME=$(basename $0)
-DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
+DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf.template"
 
 # check if we have ipv6 available
 if [ ! -f "/proc/net/if_inet6" ]; then


### PR DESCRIPTION
### Description

The templating of the nginx config overrides the changes made by the IPv6 init script. This PR instead changes the template file.

### Addressed Issue

None

### Additional Details

Initial implementations:

- https://github.com/DependencyTrack/frontend/pull/427
- https://github.com/DependencyTrack/frontend/pull/621

Broken by: https://github.com/DependencyTrack/frontend/pull/801


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~