### PR TITLE
Show component properties to users with VIEW_PORTFOLIO permission

### DIFF
--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -367,7 +367,7 @@
         size="md"
         variant="outline-primary"
         v-b-modal.componentPropertiesModal
-        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
+        v-permission="PERMISSIONS.VIEW_PORTFOLIO"
         >{{ $t('message.properties') }}</b-button
       >
       <b-button size="md" variant="secondary" @click="cancel()">{{

--- a/src/views/portfolio/projects/ComponentPropertiesModal.vue
+++ b/src/views/portfolio/projects/ComponentPropertiesModal.vue
@@ -20,6 +20,7 @@
         size="md"
         variant="outline-danger"
         @click="deleteProperty"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         :disabled="!hasRowsSelected"
         >{{ $t('message.delete') }}</b-button
       >
@@ -29,6 +30,7 @@
       <b-button
         size="md"
         variant="primary"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         v-b-modal.componentCreatePropertyModal
         >{{ $t('message.create_property') }}</b-button
       >
@@ -39,9 +41,11 @@
 <script>
 import common from '../../../shared/common';
 import xssFilters from 'xss-filters';
+import permissionsMixin from '../../../mixins/permissionsMixin';
 
 export default {
   name: 'ComponentPropertiesModal',
+  mixins: [permissionsMixin],
   props: {
     uuid: String,
   },


### PR DESCRIPTION
### Description

With this change Users with the `VIEW_PORTFOLIO` permission can see the component properties.

### Addressed Issue

Previously the button to `Properties` in the component details modal was not shown to users not having the `PORTFOLIO_EDIT` permission.

AFAIK there is no issue for this.

### Additional Details

Details view after Change only with `VIEW_PORTFOLIO` permission:
![image](https://github.com/user-attachments/assets/a191fa99-4c1d-45d6-9ba8-414ab57082a2)

Property view only with `VIEW_PORTFOLIO` permission:
![image](https://github.com/user-attachments/assets/064d3ac3-0cd2-49d6-acc8-b086fff93425)

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~ IMHO this behavior is not mentioned in the docs
