### PR TITLE
Backport: Fix no error being displayed when submitting an invalid welcome message

### DIFF
--- a/src/views/administration/configuration/WelcomeMessage.vue
+++ b/src/views/administration/configuration/WelcomeMessage.vue
@@ -91,26 +91,20 @@ export default {
       editor.style.height = editor.scrollHeight + 'px';
     },
     saveChanges() {
-      let url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}`;
-      axios.post(url, {
-        groupName: 'general',
-        propertyName: 'welcome.message.html',
-        propertyValue: encodeURIComponent(
-          this.welcomeMessage !== '' ? this.welcomeMessage : ' ',
-        ),
-      });
-      axios
-        .post(url, {
+      this.updateConfigProperties([
+        {
+          groupName: 'general',
+          propertyName: 'welcome.message.html',
+          propertyValue: encodeURIComponent(
+            this.welcomeMessage !== '' ? this.welcomeMessage : ' ',
+          ),
+        },
+        {
           groupName: 'general',
           propertyName: 'welcome.message.enabled',
           propertyValue: this.isWelcomeMessage,
-        })
-        .then((response) => {
-          this.$toastr.s(this.$t('admin.configuration_saved'));
-        })
-        .catch((error) => {
-          this.$toastr.w(this.$t('condition.unsuccessful_action'));
-        });
+        },
+      ]);
     },
   },
 };


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes no error being displayed when submitting an invalid welcome message.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/frontend/issues/1090
Backports #1091

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
