### PR TITLE
Backport: Show component properties to users with `VIEW_PORTFOLIO` permission

### DIFF
--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -367,7 +367,7 @@
         size="md"
         variant="outline-primary"
         v-b-modal.componentPropertiesModal
-        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
+        v-permission="PERMISSIONS.VIEW_PORTFOLIO"
         >{{ $t('message.properties') }}</b-button
       >
       <b-button size="md" variant="secondary" @click="cancel()">{{

--- a/src/views/portfolio/projects/ComponentPropertiesModal.vue
+++ b/src/views/portfolio/projects/ComponentPropertiesModal.vue
@@ -20,6 +20,7 @@
         size="md"
         variant="outline-danger"
         @click="deleteProperty"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         :disabled="!hasRowsSelected"
         >{{ $t('message.delete') }}</b-button
       >
@@ -29,6 +30,7 @@
       <b-button
         size="md"
         variant="primary"
+        v-permission="PERMISSIONS.PORTFOLIO_MANAGEMENT"
         v-b-modal.componentCreatePropertyModal
         >{{ $t('message.create_property') }}</b-button
       >
@@ -39,9 +41,11 @@
 <script>
 import common from '../../../shared/common';
 import xssFilters from 'xss-filters';
+import permissionsMixin from '../../../mixins/permissionsMixin';
 
 export default {
   name: 'ComponentPropertiesModal',
+  mixins: [permissionsMixin],
   props: {
     uuid: String,
   },


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Shows component properties to users with `VIEW_PORTFOLIO` permission.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #1095

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
