### PR TITLE
Backport: Prefill *Team* input in *Create Project* dialog based on user's team membership

### DIFF
--- a/src/views/portfolio/projects/ProjectCreateProjectModal.vue
+++ b/src/views/portfolio/projects/ProjectCreateProjectModal.vue
@@ -223,6 +223,7 @@ import { Switch as cSwitch } from '@coreui/vue';
 import permissionsMixin from '../../../mixins/permissionsMixin';
 import Multiselect from 'vue-multiselect';
 import BInputGroupFormSwitch from '@/forms/BInputGroupFormSwitch.vue';
+import common from '../../../shared/common';
 
 export default {
   name: 'ProjectCreateProjectModal',
@@ -312,7 +313,9 @@ export default {
     async getACLEnabled() {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_CONFIG_PROPERTY}/public/access-management/acl.enabled`;
       let response = await this.axios.get(url);
-      this.requiresTeam = response.data.propertyValue.toString();
+      this.requiresTeam = common.toBoolean(
+        response.data.propertyValue.toString(),
+      );
     },
     async getAvailableTeams() {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_TEAM}/visible`;

--- a/src/views/portfolio/projects/ProjectCreateProjectModal.vue
+++ b/src/views/portfolio/projects/ProjectCreateProjectModal.vue
@@ -317,15 +317,13 @@ export default {
     async getAvailableTeams() {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_TEAM}/visible`;
       let response = await this.axios.get(url);
-      console.log(response.data);
       let convertedTeams = response.data.map((team) => {
-        console.log(team.uuid);
         return { text: team.name, value: team.uuid };
       });
       this.availableTeams = convertedTeams;
       this.teams = response.data;
       if (this.requiresTeam && this.availableTeams.length == 1) {
-        this.project.team = teams[0][0].value;
+        this.project.team = this.availableTeams[0].value;
         this.isDisabled = true;
       }
       this.availableTeams.sort(function (a, b) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prefills *Team* input in *Create Project* dialog based on user's team membership.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/frontend/issues/1088
Backports https://github.com/DependencyTrack/frontend/pull/1089

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
Signed-off-by: Thomas Schauer-Koeckeis <thomas.schauer-koeckeis@rohde-schwarz.com>