### PR TITLE
Backport: Fix policy violation tab indicators being populated incorrectly

### DIFF
--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -519,7 +519,7 @@ export default {
             0,
           );
           this.policyViolationsFailTotal = common.valueWithDefault(
-            this.project.metrics.policyViolationsFailTotal,
+            this.project.metrics.policyViolationsFail,
             0,
           );
           this.policyViolationsFailUnaudited = common.valueWithDefault(
@@ -527,7 +527,7 @@ export default {
             0,
           );
           this.policyViolationsWarnTotal = common.valueWithDefault(
-            this.project.metrics.policyViolationsWarnTotal,
+            this.project.metrics.policyViolationsWarn,
             0,
           );
           this.policyViolationsWarnUnaudited = common.valueWithDefault(
@@ -535,7 +535,7 @@ export default {
             0,
           );
           this.policyViolationsInfoTotal = common.valueWithDefault(
-            this.project.metrics.policyViolationsInfoTotal,
+            this.project.metrics.policyViolationsInfo,
             0,
           );
           this.policyViolationsInfoUnaudited = common.valueWithDefault(


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes policy violation tab indicators being populated incorrectly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #1170
Backports #1171

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
