### PR TITLE
Backport: Fix wrong policy violation tab indicator visibility conditions

### DIFF
--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -313,9 +313,10 @@
             v-b-tooltip.hover
             :title="$t('policy_violation.total')"
             >{{
-              showSuppressedViolations
+              policyViolationsTotal
+              /*showSuppressedViolations
                 ? policyViolationsTotal
-                : policyViolationsUnaudited
+                : policyViolationsUnaudited*/
             }}</b-badge
           >
           <b-badge
@@ -323,9 +324,10 @@
             v-b-tooltip.hover
             :title="$t('policy_violation.infos')"
             >{{
-              showSuppressedViolations
+              policyViolationsInfoTotal
+              /*showSuppressedViolations
                 ? policyViolationsInfoTotal
-                : policyViolationsInfoUnaudited
+                : policyViolationsInfoUnaudited*/
             }}</b-badge
           >
           <b-badge
@@ -333,9 +335,10 @@
             v-b-tooltip.hover
             :title="$t('policy_violation.warns')"
             >{{
-              showSuppressedViolations
+              policyViolationsWarnTotal
+              /*showSuppressedViolations
                 ? policyViolationsWarnTotal
-                : policyViolationsWarnUnaudited
+                : policyViolationsWarnUnaudited*/
             }}</b-badge
           >
           <b-badge
@@ -343,9 +346,10 @@
             v-b-tooltip.hover
             :title="$t('policy_violation.fails')"
             >{{
-              showSuppressedViolations
+              policyViolationsFailTotal
+              /*showSuppressedViolations
                 ? policyViolationsFailTotal
-                : policyViolationsFailUnaudited
+                : policyViolationsFailUnaudited*/
             }}</b-badge
           >
         </template>
@@ -451,11 +455,14 @@ export default {
       policyViolationsTotal: 0,
       policyViolationsUnaudited: 0,
       policyViolationsFailTotal: 0,
-      policyViolationsFailUnaudited: 0,
+      // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+      // policyViolationsFailUnaudited: 0,
       policyViolationsWarnTotal: 0,
-      policyViolationsWarnUnaudited: 0,
+      // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+      // policyViolationsWarnUnaudited: 0,
       policyViolationsInfoTotal: 0,
-      policyViolationsInfoUnaudited: 0,
+      // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+      // policyViolationsInfoUnaudited: 0,
       tabIndex: 0,
     };
   },
@@ -522,26 +529,29 @@ export default {
             this.project.metrics.policyViolationsFail,
             0,
           );
-          this.policyViolationsFailUnaudited = common.valueWithDefault(
-            this.project.metrics.policyViolationsFailUnaudited,
-            0,
-          );
+          // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+          // this.policyViolationsFailUnaudited = common.valueWithDefault(
+          //   this.project.metrics.policyViolationsFailUnaudited,
+          //   0,
+          // );
           this.policyViolationsWarnTotal = common.valueWithDefault(
             this.project.metrics.policyViolationsWarn,
             0,
           );
-          this.policyViolationsWarnUnaudited = common.valueWithDefault(
-            this.project.metrics.policyViolationsWarnUnaudited,
-            0,
-          );
+          // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+          // this.policyViolationsWarnUnaudited = common.valueWithDefault(
+          //   this.project.metrics.policyViolationsWarnUnaudited,
+          //   0,
+          // );
           this.policyViolationsInfoTotal = common.valueWithDefault(
             this.project.metrics.policyViolationsInfo,
             0,
           );
-          this.policyViolationsInfoUnaudited = common.valueWithDefault(
-            this.project.metrics.policyViolationsInfoUnaudited,
-            0,
-          );
+          // TODO: Requires https://github.com/DependencyTrack/dependency-track/pull/3615.
+          // this.policyViolationsInfoUnaudited = common.valueWithDefault(
+          //   this.project.metrics.policyViolationsInfoUnaudited,
+          //   0,
+          // );
           EventBus.$emit('addCrumb', this.projectLabel);
           this.$title = this.projectLabel;
         });


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes wrong policy violation tab indicator visibility conditions.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1170
Relates to #1171
Backports #1174

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
