### PR TITLE
Add autocomplete to project collection logic tag dropdown

### DIFF
--- a/src/views/portfolio/projects/ProjectCreateProjectModal.vue
+++ b/src/views/portfolio/projects/ProjectCreateProjectModal.vue
@@ -83,6 +83,7 @@
             :tags="collectionTags"
             :add-on-key="addOnKeys"
             :placeholder="$t('message.project_add_collection_tag')"
+            :autocomplete-items="tagsAutoCompleteItems"
             @tags-changed="
               (newCollectionTags) => (this.collectionTags = newCollectionTags)
             "
@@ -315,7 +316,12 @@ export default {
   },
   computed: {},
   watch: {
-    tag: 'searchTags',
+    tag(input) {
+      this.searchTags(input);
+    },
+    collectionTagTyping(input) {
+      this.searchTags(input);
+    },
   },
   methods: {
     async getACLEnabled() {
@@ -465,14 +471,14 @@ export default {
         });
       }
     },
-    searchTags: function () {
-      if (!this.tag) {
+    searchTags: function (input) {
+      if (!input) {
         return;
       }
 
       clearTimeout(this.tagsAutoCompleteDebounce);
       this.tagsAutoCompleteDebounce = setTimeout(() => {
-        const url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}?searchText=${encodeURIComponent(this.tag)}&pageNumber=1&pageSize=6`;
+        const url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}?searchText=${encodeURIComponent(input)}&pageNumber=1&pageSize=6`;
         this.axios.get(url).then((response) => {
           this.tagsAutoCompleteItems = response.data.map((tag) => {
             return { text: tag.name };

--- a/src/views/portfolio/projects/ProjectDetailsModal.vue
+++ b/src/views/portfolio/projects/ProjectDetailsModal.vue
@@ -85,6 +85,7 @@
             :tags="collectionTags"
             :add-on-key="addOnKeys"
             :placeholder="$t('message.project_add_collection_tag')"
+            :autocomplete-items="tagsAutoCompleteItems"
             @tags-changed="
               (newCollectionTags) => (this.collectionTags = newCollectionTags)
             "
@@ -674,7 +675,12 @@ export default {
     });
   },
   watch: {
-    tag: 'searchTags',
+    tag(input) {
+      this.searchTags(input);
+    },
+    collectionTagTyping(input) {
+      this.searchTags(input);
+    },
   },
   methods: {
     initializeTags: function () {
@@ -797,14 +803,14 @@ export default {
         });
       }
     },
-    searchTags: function () {
-      if (!this.tag) {
+    searchTags: function (input) {
+      if (!input) {
         return;
       }
 
       clearTimeout(this.tagsAutoCompleteDebounce);
       this.tagsAutoCompleteDebounce = setTimeout(() => {
-        const url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}?searchText=${encodeURIComponent(this.tag)}&pageNumber=1&pageSize=6`;
+        const url = `${this.$api.BASE_URL}/${this.$api.URL_TAG}?searchText=${encodeURIComponent(input)}&pageNumber=1&pageSize=6`;
         this.axios.get(url).then((response) => {
           this.tagsAutoCompleteItems = response.data.map((tag) => {
             return { text: tag.name };


### PR DESCRIPTION
### Description

Added autocomplete to Project Collection Logic's tags dropdown to make the UX consistent as "Tags" dropdown within the same modal.

### Addressed Issue

Closes: #1147  

### Additional Details

- Updated `searchTags` method to receive the input string as a parameter so the method can be used for both collection tag and project tag.
- Tag dropdowns share `tagsAutoCompleteItems` for autocomplete list since only one dropdown can be focused at a time.

Autocomplete screenshot: 

![dependency-track-frontend-tag-dropdown](https://github.com/user-attachments/assets/76224be7-de67-479b-b12b-c0c473b697d9)


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
