### PR TITLE
enhancement: add focus indicator to hamburger menu button

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -340,6 +340,12 @@ h6 {
 button:focus {
   outline: 0;
 }
+.navbar-toggler:focus,
+.sidebar-toggler:focus,
+.c-header-toggler:focus {
+  outline: 2px solid $light-blue !important;
+  outline-offset: 2px;
+}
 .badge-tab-total {
   border: 1px solid #60768c !important;
   background-color: $grey-900 !important;


### PR DESCRIPTION
### 📝 Description

This change adds a visible focus indicator to the hamburger menu button (`SidebarToggler`) to improve keyboard accessibility. It ensures that when users navigate using the `Tab` key, the button receives a distinct outline, making it easier to identify which element is currently focused.

---

### 🐛 Addressed Issue

[Issues 1202](https://github.com/DependencyTrack/frontend/issues/1202)

---

### 🔧 Additional Details

Added the following CSS rule to apply a visible focus indicator:

```scss
.navbar-toggler:focus,
.sidebar-toggler:focus,
.c-header-toggler:focus {
  outline: 2px solid $light-blue !important;
  outline-offset: 2px;
}
```

This helps meet accessibility standards and provides a better experience for keyboard-only users.

---

Tu veux que je remplisse aussi la checklist ?
### Checklist

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
