### PR TITLE
Fix tag autocomplete dropdown library style overriding issue

### DIFF
--- a/src/assets/scss/vendors/vue-tags-input/_vue-tags-input.scss
+++ b/src/assets/scss/vendors/vue-tags-input/_vue-tags-input.scss
@@ -25,7 +25,7 @@
 }
 
 /* some stylings for the autocomplete layer */
-.vue-tags-input .ti-autocomplete {
+.vue-tags-input div.ti-autocomplete {
   background: #283944;
   border: 1px solid $tags-input-border-color;
   border-top: none;


### PR DESCRIPTION
### Description

Updated tag dropdown autocomplete's style selector to prevent the input library's style overriding the custom style from the app which made it hard to read due to low contrast

### Addressed Issue

Closes: #1146 

### Additional Details

The issue is caused by the library's default style occasionally overriding the custom style.
`.ti-autocomplete` is always a `div` tag [(source code)](https://github.com/JohMun/vue-tags-input/blob/294026aeed583154df3aeaf9f8007136404c132e/vue-tags-input/vue-tags-input.vue#L150-L154) so added the tag name to the style selector to override the default style.

![Screenshot 2025-03-31 at 10 41 27 PM](https://github.com/user-attachments/assets/88ec5f3d-8248-4fd9-9e93-f290eebff97b)


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
