### PR TITLE
Display last vuln analysis timestamp in project view

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Letzter BOM-Import",
     "last_measurement": "Letzte Messung",
     "last_seen": "Zuletzt gesehen bei",
+    "last_vulnerability_analysis": "Letzte Schwachstellen-Analyse",
     "latest": "Aktuellste",
     "latest_version": "Letzte Version",
     "legal": "Rechtliches",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Last BOM Import",
     "last_measurement": "Last Measurement",
     "last_seen": "Last Seen At",
+    "last_vulnerability_analysis": "Last Vulnerability Analysis",
     "latest": "Latest",
     "latest_version": "Latest Version",
     "legal": "Legal",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Importación de la última lista de materiales",
     "last_measurement": "Última medición",
     "last_seen": "Visto por última vez en",
+    "last_vulnerability_analysis": "Último análisis de vulnerabilidad",
     "latest": "El último",
     "latest_version": "Ultima versión",
     "legal": "Legal",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Dernière importation de nomenclature",
     "last_measurement": "Dernière mesure",
     "last_seen": "Vu la dernière fois à",
+    "last_vulnerability_analysis": "Dernière analyse de vulnérabilité",
     "latest": "Dernier",
     "latest_version": "Dernière version",
     "legal": "Légal",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -575,6 +575,7 @@
     "last_bom_import": "अंतिम BOM आयात",
     "last_measurement": "अंतिम माप",
     "last_seen": "आखिरी बार देखा",
+    "last_vulnerability_analysis": "अंतिम भेद्यता विश्लेषण",
     "latest": "नवीनतम",
     "latest_version": "नवीनतम संस्करण",
     "legal": "कानूनी",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Ultima importazione distinta base",
     "last_measurement": "Ultima misurazione",
     "last_seen": "Visto l'ultima volta a",
+    "last_vulnerability_analysis": "Ultima analisi di vulnerabilità",
     "latest": "Ultimo",
     "latest_version": "Ultima versione",
     "legal": "Legale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -575,6 +575,7 @@
     "last_bom_import": "最後のBOMインポート",
     "last_measurement": "最終測定",
     "last_seen": "最終確認",
+    "last_vulnerability_analysis": "最後の脆弱性分析",
     "latest": "最新",
     "latest_version": "最新バージョン",
     "legal": "法律上の",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Ostatni import BOM",
     "last_measurement": "Ostatni pomiar",
     "last_seen": "Ostatnio widziany w",
+    "last_vulnerability_analysis": "Ostatnia analiza podatności",
     "latest": "Najnowszy",
     "latest_version": "Ostatnia wersja",
     "legal": "Prawny",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Última importação de BOM",
     "last_measurement": "Última medição",
     "last_seen": "Visto por último em",
+    "last_vulnerability_analysis": "Última análise de vulnerabilidade",
     "latest": "Mais recente",
     "latest_version": "Última versão",
     "legal": "Jurídico",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Última importação de BOM",
     "last_measurement": "Última medição",
     "last_seen": "Visto por último em",
+    "last_vulnerability_analysis": "Última análise de vulnerabilidade",
     "latest": "Mais recente",
     "latest_version": "Última versão",
     "legal": "Jurídico",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Последний импорт BOM",
     "last_measurement": "Последнее измерение",
     "last_seen": "Последний раз замечено",
+    "last_vulnerability_analysis": "Последний анализ уязвимости",
     "latest": "Последний",
     "latest_version": "Последняя версия",
     "legal": "Юридический",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -575,6 +575,7 @@
     "last_bom_import": "Останній імпорт специфікації",
     "last_measurement": "Останнє вимірювання",
     "last_seen": "Останнє побачення в",
+    "last_vulnerability_analysis": "Останній аналіз вразливості",
     "latest": "Останній",
     "latest_version": "Остання версія",
     "legal": "юридичний",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -575,6 +575,7 @@
     "last_bom_import": "上次 BOM 导入",
     "last_measurement": "最后一次评估",
     "last_seen": "最后上线时间",
+    "last_vulnerability_analysis": "最后的漏洞分析",
     "latest": "最新的",
     "latest_version": "最新版本",
     "legal": "合法的",

--- a/src/views/portfolio/projects/ProjectDashboard.vue
+++ b/src/views/portfolio/projects/ProjectDashboard.vue
@@ -7,9 +7,13 @@
             {{ $t('message.project_vulnerabilities') }}
           </h4>
           <table class="small text-muted" style="border: 0">
-            <tr>
+            <tr v-if="this.project.collectionLogic === 'NONE'">
               <td>{{ $t('message.last_bom_import') }}:</td>
               <td>{{ lastBomImport }}</td>
+            </tr>
+            <tr v-if="this.project.collectionLogic === 'NONE'">
+              <td>{{ $t('message.last_vulnerability_analysis') }}:</td>
+              <td>{{ lastVulnAnalysis }}</td>
             </tr>
             <tr>
               <td>{{ $t('message.last_measurement') }}:</td>
@@ -228,6 +232,7 @@ export default {
       suppressed: 0,
       lastMeasurement: 'n/a',
       lastBomImport: 'n/a',
+      lastVulnAnalysis: 'n/a',
     };
   },
   methods: {
@@ -296,6 +301,15 @@ export default {
         );
       } else {
         this.lastBomImport = 'n/a';
+      }
+
+      if (newProject && newProject.lastVulnerabilityAnalysis) {
+        this.lastVulnAnalysis = common.formatTimestamp(
+          newProject.lastVulnerabilityAnalysis,
+          true,
+        );
+      } else {
+        this.lastVulnAnalysis = 'n/a';
       }
     },
   },


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Displays last vuln analysis timestamp in project view.

The timestamp field was added to the project model in https://github.com/DependencyTrack/dependency-track/issues/4620.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

<img width="405" alt="image" src="https://github.com/user-attachments/assets/7e494367-4524-4ecf-8c43-c0309a8f47b1" />

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
