### PR TITLE
Show collection projects using tag in tag list

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Die Metriken des Sammlungsprojekts werden berechnet, indem die Zahlen aller direkten untergeordneten Elemente mit dem Tag „{tag}“ aggregiert werden.",
     "collection_logic_metrics_by_aggregate_latest_version": "Die Metriken des Sammlungsprojekts werden durch die Aggregation der Anzahl der neuesten Versionen direkter untergeordneter Elemente berechnet.",
     "collection_projects": "Projekte in Sammlung",
+    "collection_projects_using_tag": "Projektsammlungen mit Tag {tag}",
     "comment": "Kommentar",
     "comments": "Kommentare",
     "component": "Komponente",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Metrics of collection project are calculated by aggregating numbers of direct children with tag '{tag}'.",
     "collection_logic_metrics_by_aggregate_latest_version": "Metrics of collection project are calculated by aggregating numbers of latest versions of direct children.",
     "collection_projects": "Collection Projects",
+    "collection_projects_using_tag": "Collection projects using tag {tag}",
     "comment": "Comment",
     "comments": "Comments",
     "component": "Component",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Las métricas del proyecto de recopilación se calculan agregando números de hijos directos con la etiqueta '{tag}'.",
     "collection_logic_metrics_by_aggregate_latest_version": "Las métricas del proyecto de recopilación se calculan agregando números de las últimas versiones de los hijos directos.",
     "collection_projects": "Proyectos de colección",
+    "collection_projects_using_tag": "Proyectos de recopilación utilizando la etiqueta {tag}",
     "comment": "Comentario",
     "comments": "Comentarios",
     "component": "Componente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Les métriques du projet de collection sont calculées en agrégeant le nombre d'enfants directs avec la balise « {tag} ».",
     "collection_logic_metrics_by_aggregate_latest_version": "Les mesures du projet de collection sont calculées en agrégeant le nombre des dernières versions des enfants directs.",
     "collection_projects": "Projets de collecte",
+    "collection_projects_using_tag": "Projets de collecte à l'aide de tag {tag}",
     "comment": "Commentaire",
     "comments": "Commentaires",
     "component": "Composant",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "संग्रह परियोजना के मेट्रिक्स की गणना '{टैग}' टैग वाले प्रत्यक्ष बच्चों की संख्या को एकत्रित करके की जाती है।",
     "collection_logic_metrics_by_aggregate_latest_version": "संग्रह परियोजना के मेट्रिक्स की गणना प्रत्यक्ष बच्चों के नवीनतम संस्करणों की संख्या को एकत्रित करके की जाती है।",
     "collection_projects": "संग्रह परियोजनाएँ",
+    "collection_projects_using_tag": "टैग {tag} का उपयोग करके संग्रह परियोजनाएं",
     "comment": "टिप्पणी",
     "comments": "टिप्पणियाँ",
     "component": "अवयव",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Le metriche del progetto di raccolta vengono calcolate aggregando il numero di figli diretti con tag '{tag}'.",
     "collection_logic_metrics_by_aggregate_latest_version": "Le metriche del progetto di raccolta vengono calcolate aggregando i numeri delle ultime versioni dei figli diretti.",
     "collection_projects": "Progetti di raccolta",
+    "collection_projects_using_tag": "Progetti di raccolta usando tag {tag}",
     "comment": "Commento",
     "comments": "Commenti",
     "component": "Componente",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "コレクション プロジェクトのメトリクスは、タグ「{tag}」を持つ直接の子の数を集計することによって計算されます。",
     "collection_logic_metrics_by_aggregate_latest_version": "コレクション プロジェクトのメトリックは、直接の子の最新バージョンの数を集計することによって計算されます。",
     "collection_projects": "コレクションプロジェクト",
+    "collection_projects_using_tag": "タグ{tag}を使用したコレクションプロジェクト",
     "comment": "コメント",
     "comments": "コメント",
     "component": "コンポーネント",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Metryki projektu kolekcji są obliczane poprzez agregację liczby bezpośrednich elementów podrzędnych ze znacznikiem „{tag}”.",
     "collection_logic_metrics_by_aggregate_latest_version": "Metryki projektu kolekcji są obliczane poprzez agregację liczby najnowszych wersji bezpośrednich elementów podrzędnych.",
     "collection_projects": "Projekty kolekcji",
+    "collection_projects_using_tag": "Projekty kolekcyjne za pomocą tag {tag}",
     "comment": "Komentarz",
     "comments": "Uwagi",
     "component": "Część",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "As métricas do projeto de coleção são calculadas agregando o número de filhos diretos com a tag '{tag}'.",
     "collection_logic_metrics_by_aggregate_latest_version": "As métricas do projeto de coleta são calculadas agregando os números das versões mais recentes dos filhos diretos.",
     "collection_projects": "Projetos de Coleção",
+    "collection_projects_using_tag": "Projetos de coleção usando tag {tag}",
     "comment": "Comente",
     "comments": "Comentários",
     "component": "Componente",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "As métricas do projeto de coleção são calculadas agregando o número de filhos diretos com a tag '{tag}'.",
     "collection_logic_metrics_by_aggregate_latest_version": "As métricas do projeto de coleta são calculadas agregando os números das versões mais recentes dos filhos diretos.",
     "collection_projects": "Projetos de Coleção",
+    "collection_projects_using_tag": "Projetos de coleção usando tag {tag}",
     "comment": "Comente",
     "comments": "Comentários",
     "component": "Componente",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Метрики проекта сбора рассчитываются путем агрегирования количества прямых дочерних элементов с тегом «{tag}».",
     "collection_logic_metrics_by_aggregate_latest_version": "Метрики проекта сбора рассчитываются путем агрегирования количества последних версий прямых дочерних элементов.",
     "collection_projects": "Коллекционные проекты",
+    "collection_projects_using_tag": "Коллекционные проекты с использованием тега {tag}",
     "comment": "Комментарий",
     "comments": "Комментарии",
     "component": "Компонент",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "Показники проекту колекції обчислюються шляхом агрегування кількості прямих дочірніх елементів із тегом \"{tag}\".",
     "collection_logic_metrics_by_aggregate_latest_version": "Показники проекту колекції обчислюються шляхом агрегування чисел останніх версій прямих дочірніх елементів.",
     "collection_projects": "Колекція проектів",
+    "collection_projects_using_tag": "Проекти колекції з використанням тегу {tag}",
     "comment": "коментар",
     "comments": "Коментарі",
     "component": "компонент",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -392,6 +392,7 @@
     "collection_logic_metrics_by_aggregate_direct_children_with_tags": "收集项目的指标是通过聚合带有标签“{tag}”的直接子项的数量来计算的。",
     "collection_logic_metrics_by_aggregate_latest_version": "收集项目的指标是通过汇总直接子项的最新版本的数量来计算的。",
     "collection_projects": "收藏项目",
+    "collection_projects_using_tag": "使用标签{tag}收集项目",
     "comment": "评论",
     "comments": "评论",
     "component": "组件",

--- a/src/views/portfolio/tags/TagList.vue
+++ b/src/views/portfolio/tags/TagList.vue
@@ -19,6 +19,7 @@ import xssFilters from 'xss-filters';
 import permissionsMixin from '../../../mixins/permissionsMixin';
 import routerMixin from '../../../mixins/routerMixin';
 import bootstrapTableMixin from '@/mixins/bootstrapTableMixin';
+import TaggedCollectionProjectListModal from '@/views/portfolio/tags/TaggedCollectionProjectListModal.vue';
 import TaggedNotificationRuleListModal from '@/views/portfolio/tags/TaggedNotificationRuleListModal.vue';
 import TaggedPoliciesListModal from '@/views/portfolio/tags/TaggedPoliciesListModal.vue';
 import TaggedProjectListModal from '@/views/portfolio/tags/TaggedProjectListModal.vue';
@@ -84,6 +85,37 @@ export default {
                 <div>
                   <b-link v-b-modal="\`taggedProjectListModal-${index}\`">{{ value }}</b-link>
                   <tagged-project-list-modal :tag="tagName" :index="index"/>
+                </div>`,
+              data() {
+                return {
+                  index: index,
+                  tagName: row.name,
+                  error: row.error,
+                  value: value,
+                };
+              },
+            });
+          },
+        },
+        {
+          title: this.$t('message.collection_projects'),
+          field: 'collectionProjectCount',
+          sortable: true,
+          formatter: (value, row, index) => {
+            if (value === 0) {
+              return value;
+            }
+
+            return this.vueFormatter({
+              i18n,
+              components: {
+                TaggedCollectionProjectListModal,
+              },
+              mixins: [permissionsMixin],
+              template: `
+                <div>
+                  <b-link v-b-modal="\`taggedCollectionProjectListModal-${index}\`">{{ value }}</b-link>
+                  <tagged-collection-project-list-modal :tag="tagName" :index="index"/>
                 </div>`,
               data() {
                 return {

--- a/src/views/portfolio/tags/TaggedCollectionProjectListModal.vue
+++ b/src/views/portfolio/tags/TaggedCollectionProjectListModal.vue
@@ -1,0 +1,104 @@
+<template>
+  <b-modal
+    :id="`taggedCollectionProjectListModal-${index}`"
+    size="lg"
+    hide-header-close
+    no-stacking
+    v-permission="'VIEW_PORTFOLIO'"
+    :title="$t('message.collection_projects_using_tag', { tag: this.tag })"
+  >
+    <bootstrap-table
+      ref="table"
+      :columns="columns"
+      :data="data"
+      :options="options"
+    >
+    </bootstrap-table>
+    <template v-slot:modal-footer="{ cancel }">
+      <b-button size="md" variant="secondary" @click="cancel()"
+        >{{ $t('message.cancel') }}
+      </b-button>
+    </template>
+  </b-modal>
+</template>
+
+<script>
+import xssFilters from 'xss-filters';
+import permissionsMixin from '../../../mixins/permissionsMixin';
+import common from '../../../shared/common';
+import router from '@/router';
+import bootstrapTableMixin from '@/mixins/bootstrapTableMixin';
+
+export default {
+  props: {
+    tag: String,
+    index: Number,
+  },
+  mixins: [bootstrapTableMixin, permissionsMixin],
+  methods: {
+    apiUrl: function () {
+      return `${this.$api.BASE_URL}/${this.$api.URL_TAG}/${encodeURIComponent(this.tag)}/collectionProject`;
+    },
+    refreshTable: function () {
+      this.$refs.table.refresh({
+        url: this.apiUrl(),
+        pageNumber: 1,
+        silent: true,
+      });
+    },
+  },
+  data() {
+    return {
+      labelIcon: {
+        dataOn: '\u2713',
+        dataOff: '\u2715',
+      },
+      columns: [
+        {
+          title: this.$t('message.name'),
+          field: 'name',
+          sortable: true,
+          formatter: (value, row) => {
+            // TODO: Close modal when link is clicked.
+            const href = router.resolve({
+              name: 'Project',
+              params: { uuid: row.uuid },
+            }).href;
+            return `<a href="${href}">${xssFilters.inHTMLData(value)}</a>`;
+          },
+        },
+        {
+          title: this.$t('message.version'),
+          field: 'version',
+          sortable: true,
+          formatter(value) {
+            return xssFilters.inHTMLData(common.valueWithDefault(value, ''));
+          },
+        },
+      ],
+      data: [],
+      options: {
+        buttonsOrder: ['refresh', 'columns'],
+        search: true,
+        showColumns: true,
+        showRefresh: true,
+        pagination: true,
+        silentSort: false,
+        sidePagination: 'server',
+        queryParamsType: 'pageSize',
+        pageList: '[10, 25, 50, 100]',
+        pageSize: 10,
+        icons: {
+          refresh: 'fa-refresh',
+        },
+        toolbar: '#tagsToolbar',
+        responseHandler: function (res, xhr) {
+          res.total = xhr.getResponseHeader('X-Total-Count');
+          return res;
+        },
+        url: this.apiUrl(),
+      },
+    };
+  },
+};
+</script>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Shows collection projects using tag in tag list.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/pull/4858
Backports https://github.com/DependencyTrack/frontend/pull/1237

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
