### PR TITLE
fix: save condition on operator change in PolicyCondition.vue

### DIFF
--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -17,6 +17,7 @@
         <b-input-group-form-select
           id="input-operator"
           required="true"
+          v-on:change="saveCondition"
           v-model="operator"
           :options="operators"
         />


### PR DESCRIPTION
### Description
Fix policy condition operator changes not being saved automatically. Added missing change event handler to the operator dropdown to trigger `saveCondition()` when the operator value is modified, ensuring consistency with subject and value field behavior.

### Addressed Issue
Fixes #[508] - Policy condition operator changes not being saved

**Solution:** Added `v-on:change="saveCondition"` to the operator select component, matching the pattern used by other form fields in the component.

**Technical Details:**
- The fix is minimal and follows the existing component pattern
- No additional logic was needed since `saveCondition()` already handles operator changes correctly
- This ensures immediate persistence of operator changes without requiring additional user interaction

**Before:** Operator changes required modifying another field to trigger save
**After:** Operator changes are saved immediately upon selection

### Checklist
- [x] I have read and understand the [[contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] ~This PR introduces new or alters existing behavior, and I have updated the [[documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs)](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~ *(No documentation changes needed - this is a bug fix that restores expected behavior)*