### PR TITLE
feat(analyzer): add option to ignore severity reported by Trivy scan

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,6 +40,7 @@
     "analyzer_snyk_why_multiple_cvss": "Why are there multiple CVSS Scores for the same vulnerability?",
     "analyzer_trivy_enable": "Enable Trivy analyzer",
     "analyzer_trivy_ignore_unfixed": "Ignore unfixed vulnerabilities",
+    "analyzer_trivy_ignore_severity": "Ignore severity reported by Trivy scan",
     "analyzer_trivy_scan_library": "Scan language-specific packages (e.g. packages installed by pip, npm, or gem)",
     "analyzer_trivy_scan_os": "Scan OS packages managed by the OS package manager (e.g. dpkg, yum, apk)",
     "analyzer_vulndb_desc": "VulnDB is a commercial service from Risk Based Security which identifies vulnerabilities in third-party components. Dependency-Track integrates natively with the VulnDB service to provide highly accurate results. Use of this analyzer requires a valid CPE for the components being analyzed.",

--- a/src/views/administration/analyzers/TrivyAnalyzer.vue
+++ b/src/views/administration/analyzers/TrivyAnalyzer.vue
@@ -55,6 +55,15 @@
         v-bind="labelIcon"
       />
       {{ $t('admin.analyzer_trivy_scan_os') }}
+      <br />
+      <c-switch
+        id="ignoreSeverity"
+        color="primary"
+        v-model="ignoreSeverity"
+        label
+        v-bind="labelIcon"
+      />
+      {{ $t('admin.analyzer_trivy_ignore_severity') }}
     </b-card-body>
     <b-card-footer>
       <b-button
@@ -91,6 +100,7 @@ export default {
       ignoreUnfixed: false,
       scanLibrary: true,
       scanOs: true,
+      ignoreSeverity: true,
     };
   },
   methods: {
@@ -126,6 +136,11 @@ export default {
           propertyName: 'trivy.scanner.scanOs',
           propertyValue: this.scanOs,
         },
+        {
+          groupName: 'scanner',
+          propertyName: 'trivy.ignore.severity',
+          propertyValue: this.ignoreSeverity,
+        },
       ]);
     },
   },
@@ -154,6 +169,9 @@ export default {
             break;
           case 'trivy.scanner.scanOs':
             this.scanOs = common.toBoolean(item.propertyValue);
+            break;
+          case 'trivy.ignore.severity':
+            this.ignoreSeverity = common.toBoolean(item.propertyValue);
             break;
         }
       }


### PR DESCRIPTION
### Description

* A new flag in the UI under:
  `Administration → Analyzer → Trivy`
  Labeled as **"Ignore severity reported by Trivy scan"**
* This flag will be enabled by default (i.e., severity is ignored).
* When disabled, the analyzer **overwrites the existing severity of a vulnerability** with the value reported by Trivy


### Checklist
- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
