### PR TITLE
feat: audit vuln toggle for hide/show aliased findings

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -913,7 +913,8 @@
     "weakness": "Schwäche",
     "will_not_fix": "Wird nicht repariert",
     "workaround_available": "Problemumgehung verfügbar",
-    "x_trust_boundary": "Vertrauensgrenze überschreiten"
+    "x_trust_boundary": "Vertrauensgrenze überschreiten",
+    "show_aliased_findings": "Aliased Erkenntnisse zeigen"
   },
   "operator": {
     "contains_all": "enthält alle",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -834,6 +834,7 @@
     "service_vulnerabilities": "Service Vulnerabilities",
     "services": "Services",
     "severity": "Severity",
+    "show_aliased_findings": "Show aliased findings",
     "show_complete_graph": "Show complete graph",
     "show_flat_view": "Show flat project view",
     "show_in_dependency_graph": "Show in dependency graph",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -913,7 +913,8 @@
     "weakness": "Debilidad",
     "will_not_fix": "No se reparara",
     "workaround_available": "Solución alternativa disponible",
-    "x_trust_boundary": "Cruzar el límite de confianza"
+    "x_trust_boundary": "Cruzar el límite de confianza",
+    "show_aliased_findings": "Mostrar hallazgos alias"
   },
   "operator": {
     "contains_all": "contiene todo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -913,7 +913,8 @@
     "weakness": "Faiblesse",
     "will_not_fix": "Ne sera pas corrigée",
     "workaround_available": "Solution de contournement disponible",
-    "x_trust_boundary": "Limte de confiance mutuelle"
+    "x_trust_boundary": "Limte de confiance mutuelle",
+    "show_aliased_findings": "Montrer des résultats aliasés"
   },
   "operator": {
     "contains_all": "contient tous",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -913,7 +913,8 @@
     "weakness": "कमजोरी",
     "will_not_fix": "ठीक नहीं होगा",
     "workaround_available": "वैकल्पिक उपाय उपलब्ध है",
-    "x_trust_boundary": "क्रॉस ट्रस्ट सीमा"
+    "x_trust_boundary": "क्रॉस ट्रस्ट सीमा",
+    "show_aliased_findings": "अलियास्ड निष्कर्ष दिखाएं"
   },
   "operator": {
     "contains_all": "इसमें सभी शामिल हैं",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -913,7 +913,8 @@
     "weakness": "Debolezza",
     "will_not_fix": "Non risolverà",
     "workaround_available": "Soluzione disponibile",
-    "x_trust_boundary": "Confine di fiducia incrociata"
+    "x_trust_boundary": "Confine di fiducia incrociata",
+    "show_aliased_findings": "Mostra risultati alias"
   },
   "operator": {
     "contains_all": "contiene tutto",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -913,7 +913,8 @@
     "weakness": "弱点",
     "will_not_fix": "修正しない",
     "workaround_available": "回避策あり",
-    "x_trust_boundary": "信頼境界を越える"
+    "x_trust_boundary": "信頼境界を越える",
+    "show_aliased_findings": "エイリアスの調査結果を表示します"
   },
   "operator": {
     "contains_all": "すべてを含む",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -913,7 +913,8 @@
     "weakness": "Słabość",
     "will_not_fix": "Nie naprawi",
     "workaround_available": "Dostępne obejście",
-    "x_trust_boundary": "Granica zaufania krzyżowego"
+    "x_trust_boundary": "Granica zaufania krzyżowego",
+    "show_aliased_findings": "Pokaż aliasowe ustalenia"
   },
   "operator": {
     "contains_all": "zawiera wszystko",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -913,7 +913,8 @@
     "weakness": "Fraqueza",
     "will_not_fix": "Não irá corrigir",
     "workaround_available": "Solução alternativa disponível",
-    "x_trust_boundary": "Limite de confiança cruzada"
+    "x_trust_boundary": "Limite de confiança cruzada",
+    "show_aliased_findings": "Mostrar descobertas alias"
   },
   "operator": {
     "contains_all": "contém tudo",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -913,7 +913,8 @@
     "weakness": "Fraqueza",
     "will_not_fix": "Não irá corrigir",
     "workaround_available": "Solução alternativa disponível",
-    "x_trust_boundary": "Limite de confiança cruzada"
+    "x_trust_boundary": "Limite de confiança cruzada",
+    "show_aliased_findings": "Mostrar descobertas alias"
   },
   "operator": {
     "contains_all": "contém tudo",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -913,7 +913,8 @@
     "weakness": "Слабость",
     "will_not_fix": "Не будет исправлено",
     "workaround_available": "Доступно обходное решение",
-    "x_trust_boundary": "Пересечение границы доверия"
+    "x_trust_boundary": "Пересечение границы доверия",
+    "show_aliased_findings": "Показывать псевдонированные выводы"
   },
   "operator": {
     "contains_all": "содержит все",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -913,7 +913,8 @@
     "weakness": "Слабкість",
     "will_not_fix": "Не виправить",
     "workaround_available": "Доступний обхідний шлях",
-    "x_trust_boundary": "Перетнути кордон довіри"
+    "x_trust_boundary": "Перетнути кордон довіри",
+    "show_aliased_findings": "Показати псевдонім висновків"
   },
   "operator": {
     "contains_all": "містить усе",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -913,7 +913,8 @@
     "weakness": "弱点",
     "will_not_fix": "不会修复",
     "workaround_available": "有解决方法",
-    "x_trust_boundary": "跨越信任边界"
+    "x_trust_boundary": "跨越信任边界",
+    "show_aliased_findings": "显示混叠的发现"
   },
   "operator": {
     "contains_all": "包含全部",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Add a new toggle to the Project Audit Vulnerabilities tab which will show/hide aliased component vulnerabilities within the list.

By default the behavior will remain the same, but the end-user has the option to toggle off the aliased results and see a non-repeating list of component vulns

![Screenshot 2025-06-17 at 11 02 42 PM](https://github.com/user-attachments/assets/72d168ff-c773-4875-8345-953dd930a389)


### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This enhancement aims to avoid end-user confusion around the list of audit vulnerabilities and their severities not matching the project vulnerability summary metrics which can occur when mirroring multiple vuln sources (ie: NVD and GHSA)

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

To avoid any backend API changes, the filtering is performed client-side by a simple algorithm

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
