### PR TITLE
Improve usability of the API key overview

### DIFF
--- a/src/views/administration/accessmanagement/ApiKeyListGroupItem.vue
+++ b/src/views/administration/accessmanagement/ApiKeyListGroupItem.vue
@@ -1,8 +1,8 @@
 <template>
   <b-list-group-item class="flex-column align-items-start">
     <div class="d-flex w-100 justify-content-between">
-      <span class="text-monospace">{{ apiKey.maskedKey }}</span>
-      <div class="d-flex">
+      <span class="text-monospace">{{ apiKey.maskedKey.split('*')[0] }}</span>
+      <div class="align-left">
         <div v-show="apiKey.legacy">
           <span
             class="ml-3"


### PR DESCRIPTION
### Description

This MR amends the ApiKeyListGroupItem component to be more friendly to smaller screen sizes.

Prior to this MR, the API Keys within a Teams detail view would 'break out' of their parent div when viewing on smaller screen sizes ( < 1700px ), resulting in a clunky UX.

These overflows, while mainly a visual defect, could cause multiple buttons to share the same location, hindering accessibility.

These changes help ensure that this content is always rendered within the parent div, regardless of screen size.

### Addressed Issue

#1295

### Additional Details

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
