### PR TITLE
Update en.json

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,7 +25,7 @@
     "analyzer_internal_fuzzy_enable": "Enable fuzzy CPE matching. Helps with inconsistent NVD data, highlighting missing risks but also increasing false positives",
     "analyzer_internal_fuzzy_exclude_internal": "Enable fuzzy CPE matching on internal components",
     "analyzer_internal_fuzzy_exclude_purl": "Enable fuzzy CPE matching on components that have a Package URL (PURL) defined",
-    "analyzer_ossindex_desc": "OSS Index is a service provided by Sonatype which identifies vulnerabilities in third-party components. Dependency-Track integrates natively with the OSS Index service to provide highly accurate results. Use of this analyzer requires a valid PackageURL for the components being analyzed.",
+    "analyzer_ossindex_desc": "OSS Index is a service provided by Sonatype which identifies vulnerabilities in third-party components. Dependency-Track integrates natively with the OSS Index service to provide highly accurate results. Rate and request metric limits may apply to requests, provide an API token for higher limits. Use of this analyzer requires a valid PackageURL for the components being analyzed.",
     "analyzer_ossindex_enable": "Enable OSS Index analyzer",
     "analyzer_snyk_alias_sync_warning": "Snyk does not differentiate between related and identical vulnerabilities. Proceed with caution.",
     "analyzer_snyk_api_version": "API Version",


### PR DESCRIPTION
Improved description for OSS Index analyzer.

### Description

Improved the description for OSS Index analyzer in the Analyzer > Sonartype OSS Index section.

### Addressed Issue

To me it was not clear why I add to provide an authentication method given that it was stated "Dependency-Track integrates natively with the OSS Index service to provide highly accurate results.". Try to have a look myself within the [Sonartype website](https://ossindex.sonatype.org/doc/rest) I found out that:

> **Rate Limiting**
Rate and request metric limits apply to requests. If limits are exceeded then responses will indicate 429 Too many requests status. There are a number of request metrics that may trigger the 429 status.
Authenticated requests have a higher limit.[ Register](https://ossindex.sonatype.org/user/register) for an account and authenticate requests to get a higher limit.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
