### PR TITLE
Feature: Show/Hide Suppressed Findings on Vulnerability Audit Grouped View

### DIFF
--- a/src/views/globalAudit/VulnerabilityAuditGroupedByVulnerability.vue
+++ b/src/views/globalAudit/VulnerabilityAuditGroupedByVulnerability.vue
@@ -26,6 +26,19 @@
           </b-form-checkbox>
         </b-form-group>
         <b-form-group
+          id="showSuppressedGrouped-form-group"
+          :label="this.$t('message.analysis_status')"
+        >
+          <b-form-checkbox
+            id="showSuppressedGrouped-form-checkbox"
+            v-model="showSuppressedGrouped"
+            value="true"
+            unchecked-value="false"
+          >
+            {{ this.$t('message.show_suppressed_findings') }}
+          </b-form-checkbox>
+        </b-form-group>
+        <b-form-group
           id="grouped-severity-form-group"
           :label="this.$t('message.severity')"
         >
@@ -196,6 +209,7 @@ export default {
     watchers() {
       return [
         this.showInactive,
+        this.showSuppressedGrouped,
         this.severitySelected,
         this.publishDateFrom,
         this.publishDateTo,
@@ -261,7 +275,7 @@ export default {
         '?showInactive=' +
         (this.showInactive === 'true') +
         '&showSuppressed=' +
-        (this.showSuppressed === 'true');
+        (this.showSuppressedGrouped === 'true');
       if (this.severitySelected && this.severitySelected.length > 0) {
         url += '&severity=' + this.severitySelected;
       }
@@ -309,6 +323,7 @@ export default {
       this.occurrencesFromWatcher();
       this.occurrencesToWatcher();
       this.showInactive = false;
+      this.showSuppressedGrouped = false;
       this.severitySelected = [];
       this.publishDateFrom = '';
       this.publishDateTo = '';
@@ -424,6 +439,7 @@ export default {
       occurrencesFromWatcher: null,
       occurrencesToWatcher: null,
       showInactive: false,
+      showSuppressedGrouped: false,
       severitySelected: [],
       severityOptions: [
         { text: 'Critical', value: 'critical' },


### PR DESCRIPTION
### Description

Adds the ability to exclude suppressed findings from the Vulnerability Audit "Grouped Vulnerabilities" tab, mirroring the functionality in the "Vulnerabilities By Occurrence" tab. Defaults to hiding suppressed findings.

Existing behaviour with suppressed findings visible:

<img width="3762" height="1420" alt="issue-4507-show-suppressed-on" src="https://github.com/user-attachments/assets/9796ceff-245a-4d1c-8bf7-f94949c0968f" />

New behaviour with suppressed findings hidden:

<img width="3762" height="1420" alt="issue-4507-show-suppressed-off" src="https://github.com/user-attachments/assets/ae524aa0-ab19-4311-8a72-3a38c1576ac5" />

### Addressed Issue
Resolves #4507

### Additional Details
Added showSuppressed filtering based on getAllFindings(). Differs from that method though in that pagination is handled via SQL instead of retrieving all records then sublisting results which should be more performant on large result sets.

This PR covers the Frontend changes - the API changes are covered in https://github.com/DependencyTrack/dependency-track/pull/5257

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~[ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
