### PR TITLE
add maintainMetaData option to SelectPermissionModal pagination settings

### DIFF
--- a/src/views/administration/accessmanagement/SelectPermissionModal.vue
+++ b/src/views/administration/accessmanagement/SelectPermissionModal.vue
@@ -62,6 +62,7 @@ export default {
         showRefresh: true,
         pagination: true,
         silentSort: false,
+        maintainMetaData: true,
         sidePagination: 'client',
         queryParamsType: 'pageSize',
         pageList: '[10, 25, 50, 100]',


### PR DESCRIPTION
### Description

Updated the Bootstrap Table configuration to preserve checkbox selections across pagination and page-size changes.
Previously, when users changed the number of rows per page, any selected checkboxes were cleared because the table re-rendered without retaining selection state.
This change enables the maintainSelected option, ensuring selections persist across page transitions.

[#Hacktoberfest](https://hacktoberfest.com/)

### Addressed Issue
https://github.com/DependencyTrack/frontend/issues/1344

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
