### PR TITLE
fix: don't duplicate base-path in links

### DIFF
--- a/src/views/administration/accessmanagement/SelectProjectModal.vue
+++ b/src/views/administration/accessmanagement/SelectProjectModal.vue
@@ -76,7 +76,7 @@ export default {
             const href = router.resolve({
               name: 'Project',
               params: { uuid: row.uuid },
-            }).href;
+            }).route.fullPath;
             return `<a href="${href}">${xssFilters.inHTMLData(value)}</a>`;
           },
         },

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -259,7 +259,7 @@ export default {
               this.routerFunc().resolve({
                 name: 'Project',
                 params: { uuid: row.uuid },
-              }).href,
+              }).route.fullPath,
             );
             let collectionIcon = '';
             if (row.collectionLogic !== 'NONE') {

--- a/src/views/portfolio/tags/TaggedCollectionProjectListModal.vue
+++ b/src/views/portfolio/tags/TaggedCollectionProjectListModal.vue
@@ -63,7 +63,7 @@ export default {
             const href = router.resolve({
               name: 'Project',
               params: { uuid: row.uuid },
-            }).href;
+            }).route.fullPath;
             return `<a href="${href}">${xssFilters.inHTMLData(value)}</a>`;
           },
         },

--- a/src/views/portfolio/tags/TaggedProjectListModal.vue
+++ b/src/views/portfolio/tags/TaggedProjectListModal.vue
@@ -88,7 +88,7 @@ export default {
             const href = router.resolve({
               name: 'Project',
               params: { uuid: row.uuid },
-            }).href;
+            }).route.fullPath;
             return `<a href="${href}">${xssFilters.inHTMLData(value)}</a>`;
           },
         },

--- a/src/views/portfolio/vulnerabilities/AffectedProjects.vue
+++ b/src/views/portfolio/vulnerabilities/AffectedProjects.vue
@@ -63,7 +63,7 @@ export default {
             const url = this.$router.resolve({
               name: 'Project Vulnerability Lookup',
               params: { uuid: row.uuid, vulnerability: this.vulnerability },
-            }).href;
+            }).route.fullPath;
 
             let html = `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
             if (row.dependencyGraphAvailable) {


### PR DESCRIPTION
### Description

Fixes an issue in which the base-path was duplicated while navigating to certain pages.

### Addressed Issue

Fixes #1294 
Fixes #1288 
Fixes DependencyTrack/dependency-track#4958

### Additional Details

According to the documentation of [Vue Router](https://router.vuejs.org/api/interfaces/Router.html#resolve-) the href-Property includes any existing base-path, which leads to a duplication on multiple links. To fix this route.fullPath was used instead, which does not contain the base.

<img width="722" height="116" alt="image" src="https://github.com/user-attachments/assets/04226e62-dfaa-42a3-86ee-939613e423ce" />

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
