### PR TITLE
chore: remove duplicate call to `prebuild` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "npm run serve",
     "serve": "npm run prebuild && cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
     "prebuild": "cross-env NODE_OPTIONS=--openssl-legacy-provider node update-embedded-version.js",
-    "build": "npm run prebuild && cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "eslint": "eslint . --ext .js,.vue,.json,.md,.yaml --report-unused-disable-directives",
     "eslint-fix": "eslint --ext .js,.vue,.json,.md,.yaml --fix . --report-unused-disable-directives",
     "prettier": "prettier --check --cache '**/*.{js,vue,json,md,yaml}'",


### PR DESCRIPTION
### Description

Change: removed a explicit call to `prebuild`.

Background: 

the `package.json` included a call to `prebuild` script in the `build` script.
this is not needed, since the script lifecycle ALWAYS calls the respective `pre<something>` script right before the actual script. (see [Pre & Post Scripts reference](https://docs.npmjs.com/cli/v11/using-npm/scripts#pre--post-scripts))

see here the `prebuild` script being called twice: https://github.com/DependencyTrack/frontend/actions/runs/19435034942/job/55603565520#step:4:49
```text
> @dependencytrack/frontend@4.13.0 prebuild
> cross-env NODE_OPTIONS=--openssl-legacy-provider node update-embedded-version.js


> @dependencytrack/frontend@4.13.0 build
> npm run prebuild && cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build


> @dependencytrack/frontend@4.13.0 prebuild
> cross-env NODE_OPTIONS=--openssl-legacy-provider node update-embedded-version.js
```


### Addressed Issue

none

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
