### PR TITLE
Reseting isDisabled and re-initialize teams when opening create-modal.

### DIFF
--- a/src/views/portfolio/projects/ProjectCreateProjectModal.vue
+++ b/src/views/portfolio/projects/ProjectCreateProjectModal.vue
@@ -310,6 +310,9 @@ export default {
   },
   beforeMount() {
     this.$root.$on('initializeProjectCreateProjectModal', async () => {
+      this.resetValues();
+      await this.getACLEnabled();
+      await this.getAvailableTeams();
       await this.retrieveLicenses();
       this.$root.$emit('bv::show::modal', 'projectCreateProjectModal');
     });
@@ -342,6 +345,8 @@ export default {
       if (this.requiresTeam && this.availableTeams.length == 1) {
         this.project.team = this.availableTeams[0].value;
         this.isDisabled = true;
+      } else {
+        this.isDisabled = false;
       }
       this.availableTeams.sort(function (a, b) {
         return a.text.localeCompare(b.text);
@@ -443,6 +448,7 @@ export default {
         collectionLogic: 'NONE', // set default to regular project
         team: [],
       };
+      this.isDisabled = false;
       this.tag = '';
       this.tags = [];
       this.selectedParent = null;


### PR DESCRIPTION
### Description
State of isDisabled, getACLEnabled() and getAvailableTeams() is recalculated everytime the modal is opened. Therefore, it cannot get 'stuck' in isDisabled = true. The modal shows the team selection correctly even without reloading the page. 

### Addressed Issue
Addresses issue #1409 .

### Additional Details
Used ChatGPT and Github Copilot to understand existing codebase and suggest changes. 

### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
