### PR TITLE
Add OSS Index Base URL configuration field

### DIFF
--- a/src/views/administration/analyzers/OssIndexAnalyzer.vue
+++ b/src/views/administration/analyzers/OssIndexAnalyzer.vue
@@ -21,6 +21,14 @@
       />
       {{ $t('admin.vulnsource_alias_sync_enable') }}
       <b-validated-input-group-form-input
+        id="ossindex-baseUrl"
+        :label="$t('admin.base_url')"
+        input-group-size="mb-3"
+        rules="required"
+        v-model="baseUrl"
+        lazy="true"
+      />
+      <b-validated-input-group-form-input
         id="ossindex-username"
         :label="$t('admin.registered_email_address')"
         input-group-size="mb-3"
@@ -68,6 +76,7 @@ export default {
     return {
       scannerEnabled: false,
       aliasSyncEnabled: false,
+      baseUrl: '',
       username: '',
       apitoken: '',
       labelIcon: {
@@ -88,6 +97,11 @@ export default {
           groupName: 'scanner',
           propertyName: 'ossindex.alias.sync.enabled',
           propertyValue: this.aliasSyncEnabled,
+        },
+        {
+          groupName: 'scanner',
+          propertyName: 'ossindex.base.url',
+          propertyValue: this.baseUrl,
         },
         {
           groupName: 'scanner',
@@ -115,6 +129,9 @@ export default {
             break;
           case 'ossindex.alias.sync.enabled':
             this.aliasSyncEnabled = common.toBoolean(item.propertyValue);
+            break;
+          case 'ossindex.base.url':
+            this.baseUrl = item.propertyValue;
             break;
           case 'ossindex.api.username':
             this.username = item.propertyValue;


### PR DESCRIPTION
## Summary

Adds configurable Base URL field to the OSS Index analyzer admin UI, allowing users to point to alternative OSS Index API endpoints (e.g., `https://api.guide.sonatype.com`).

## Changes

- Added Base URL input field to OSS Index analyzer configuration panel
- Field positioned between Alias Sync and Username fields
- Implements required field validation with lazy evaluation
- Uses existing translation key `admin.base_url`
- Property: `scanner.ossindex.base.url` (default: `https://ossindex.sonatype.org`)

## Implementation Details

This implementation follows the established pattern from Snyk and Trivy analyzers for consistency:
- Uses `b-validated-input-group-form-input` component
- Validation: `rules="required"`, `lazy="true"`
- Integrates with `configPropertyMixin` for API communication
- Reads from: `GET /api/v1/configProperty/`
- Writes to: `POST /api/v1/configProperty/aggregate`

## Related PRs

This PR requires the backend changes from:
- **Backend PR:** DependencyTrack/dependency-track#5736

Both PRs should be reviewed and merged together.

## Testing

Manual testing required:
1. Navigate to Admin → Analyzers → OSS Index
2. Verify Base URL field appears between Alias Sync and Username
3. Test required field validation
4. Test saving custom URL (e.g., `https://api.guide.sonatype.com`)
5. Verify persistence after page refresh
6. Verify invalid URL handling

## Files Changed

- `src/views/administration/analyzers/OssIndexAnalyzer.vue` - Added Base URL configuration field (4 changes: template, data, save, load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)