### PR TITLE
Backport: Fix release workflow

### DIFF
--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -1,9 +1,9 @@
 name: Publish CI
 
 on:
-  release:
-    types:
-      - created
+  push:
+    tags:
+      - '[0-9]*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -21,11 +21,11 @@ permissions: {}
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Required to create commits.
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+        with:
+          token: ${{ secrets.BOT_RELEASE_GITHUB_TOKEN }}
 
       - name: Set up NodeJs
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # tag=v6.3.0
@@ -41,17 +41,18 @@ jobs:
           git config user.name "dependencytrack-bot"
           git config user.email "106437498+dependencytrack-bot@users.noreply.github.com"
 
-          npm version "${VERSION_TO_BUMP}" -m "prepare-release: set version to %s"
+          npm version "${VERSION_TO_BUMP}" --tag-version-prefix="" -m "prepare-release: set version to %s"
 
-          git push origin "HEAD:${GIT_REF}"
+          VERSION=$(jq -r '.version' package.json)
+          git push origin "HEAD:${GIT_REF}" "${VERSION}"
 
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_GITHUB_TOKEN }}
           VERSION_TO_BUMP: ${{ github.event.inputs.version-to-bump }}
           GIT_REF_NAME: ${{ github.ref_name }}
         run: |-
-          VERSION=`jq -r '.version' package.json`
+          VERSION=$(jq -r '.version' package.json)
           GH_OPTS=""
 
           if [[ "${VERSION_TO_BUMP}" == *pre* ]]; then


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes release workflow.

It turns out that creating a draft release doesn't trigger a `release: created` event. Instead, we need to push a tag, which then fires the `push: tags` event.

For this to work, the push must be performed with a non-default PAT. A BOT_RELEASE_GITHUB_TOKEN secrets has been created with minimal privileges, and scoped to this repository.

Note that tags were previously created implicitly when creating the GitHub release.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
