### PR TITLE
Backport: Add project filter toggles to component search

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Beim Umleiten zum OpenID Connect-Identitätsanbieter ist ein Fehler aufgetreten",
     "only_direct_tooltip": "Nur direkte Abhängigkeiten anzeigen, transitive Abhängigkeiten ausblenden",
     "only_outdated_tooltip": "Nur Abhängigkeiten anzeigen, für die neuere stabile Versionen verfügbar sind",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Betriebsrisiko",
     "operator": "Operator",
     "osi_approved": "OSI-Zulassung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "An error occurred while redirecting to the OpenID Connect identity provider",
     "only_direct_tooltip": "Only show direct dependencies, hiding transitive dependencies",
     "only_outdated_tooltip": "Only show dependencies that have newer stable versions available",
+    "only_show_latest_project_versions": "Only show latest project versions",
     "operational_risk": "Operational Risk",
     "operator": "Operator",
     "osi_approved": "OSI Approved",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Se produjo un error al redirigir al proveedor de identidad de OpenID Connect",
     "only_direct_tooltip": "Mostrar solo dependencias directas, ocultando dependencias transitivas",
     "only_outdated_tooltip": "Mostrar solo las dependencias que tengan versiones estables más nuevas disponibles",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Riesgo operacional",
     "operator": "Operador",
     "osi_approved": "Aprobado por OSI",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Une erreur s'est produite lors de la redirection vers le fournisseur d'identité OpenID Connect",
     "only_direct_tooltip": "Afficher uniquement les dépendances directes, en masquant les dépendances transitives",
     "only_outdated_tooltip": "Afficher uniquement les dépendances pour lesquelles des versions stables plus récentes sont disponibles",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Risque opérationnel",
     "operator": "Opérateur",
     "osi_approved": "Approuvée par l'OSI",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "OpenID Connect पहचान प्रदाता पर रीडायरेक्ट करते समय एक त्रुटि हुई",
     "only_direct_tooltip": "केवल प्रत्यक्ष निर्भरताएँ दिखाएँ, सकर्मक निर्भरताएँ छिपाएँ",
     "only_outdated_tooltip": "केवल उन निर्भरताओं को दिखाएं जिनके नए स्थिर संस्करण उपलब्ध हैं",
+    "only_show_latest_project_versions": null,
     "operational_risk": "परिचालनात्मक जोखिम",
     "operator": "ऑपरेटर",
     "osi_approved": "ओएसआई स्वीकृत",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Si è verificato un errore durante il reindirizzamento al provider di identità OpenID Connect",
     "only_direct_tooltip": "Mostra solo le dipendenze dirette, nascondendo le dipendenze transitive",
     "only_outdated_tooltip": "Mostra solo le dipendenze per cui sono disponibili versioni stabili più recenti",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Rischio operativo",
     "operator": "Operatore",
     "osi_approved": "Approvato dall'OSI",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "OpenID Connect ID プロバイダーへのリダイレクト中にエラーが発生しました",
     "only_direct_tooltip": "直接的な依存関係のみを表示し、推移的な依存関係を非表示にする",
     "only_outdated_tooltip": "新しい安定バージョンが利用可能な依存関係のみを表示する",
+    "only_show_latest_project_versions": null,
     "operational_risk": "運用リスク",
     "operator": "オペレーター",
     "osi_approved": "OSI承認",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Wystąpił błąd podczas przekierowania do dostawcy tożsamości OpenID Connect",
     "only_direct_tooltip": "Pokazuj tylko zależności bezpośrednie, ukrywając zależności przechodnie",
     "only_outdated_tooltip": "Pokazuj tylko zależności, dla których dostępne są nowsze stabilne wersje",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Ryzyko operacyjne",
     "operator": "Operator",
     "osi_approved": "Zatwierdzone przez OSI",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Ocorreu um erro ao redirecionar para o provedor de identidade OpenID Connect",
     "only_direct_tooltip": "Mostrar apenas dependências diretas, ocultando dependências transitivas",
     "only_outdated_tooltip": "Mostrar apenas dependências que tenham versões estáveis mais recentes disponíveis",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Risco operacional",
     "operator": "Operador",
     "osi_approved": "Aprovado pelo OSI",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Ocorreu um erro ao redirecionar para o provedor de identidade OpenID Connect",
     "only_direct_tooltip": "Mostrar apenas dependências diretas, ocultando dependências transitivas",
     "only_outdated_tooltip": "Mostrar apenas dependências que tenham versões estáveis mais recentes disponíveis",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Risco operacional",
     "operator": "Operador",
     "osi_approved": "Aprovado pelo OSI",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Произошла ошибка при перенаправлении к поставщику идентификации OpenID Connect",
     "only_direct_tooltip": "Показывать только прямые зависимости, скрывая транзитивные зависимости",
     "only_outdated_tooltip": "Показывать только зависимости, для которых доступны более новые стабильные версии.",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Операционный риск",
     "operator": "Оператор",
     "osi_approved": "Одобрено OSI",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "Сталася помилка під час перенаправлення до постачальника ідентифікації OpenID Connect",
     "only_direct_tooltip": "Показувати лише прямі залежності, приховуючи транзитивні",
     "only_outdated_tooltip": "Показувати лише застарілі залежності, для яких доступні новіші стабільні версії",
+    "only_show_latest_project_versions": null,
     "operational_risk": "Операційний ризик",
     "operator": "Оператор",
     "osi_approved": "Схвалено OSI",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "重定向至 OpenID Connect 身分提供者時發生錯誤",
     "only_direct_tooltip": "僅顯示直接依賴關係，隱藏傳遞依賴關係",
     "only_outdated_tooltip": "僅顯示具有較新的穩定版本的依賴項",
+    "only_show_latest_project_versions": null,
     "operational_risk": "作業風險",
     "operator": "運算子",
     "osi_approved": "OSI 核准",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -641,6 +641,7 @@
     "oidc_redirect_failed": "重定向至 OpenID Connect 身份提供商时发生错误",
     "only_direct_tooltip": "仅显示直接依赖，隐藏间接依赖",
     "only_outdated_tooltip": "仅显示存在更新稳定版本的依赖项",
+    "only_show_latest_project_versions": null,
     "operational_risk": "运营风险",
     "operator": "操作人",
     "osi_approved": "OSI 认证",

--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -51,6 +51,28 @@
           }}</b-button>
         </b-col>
       </b-row>
+      <b-row class="mt-2">
+        <b-col>
+          <c-switch
+            id="showInactiveProjects"
+            color="primary"
+            v-model="showInactiveProjects"
+            label
+            v-bind="labelIcon"
+          /><span class="text-muted" style="margin-right: 1rem">{{
+            $t('message.show_inactive_projects')
+          }}</span>
+          <c-switch
+            id="onlyLatestProjectVersions"
+            color="primary"
+            v-model="onlyLatestProjectVersions"
+            label
+            v-bind="labelIcon"
+          /><span class="text-muted">{{
+            $t('message.only_show_latest_project_versions')
+          }}</span>
+        </b-col>
+      </b-row>
     </div>
     <bootstrap-table
       ref="table"
@@ -88,6 +110,17 @@ export default {
       localStorage && localStorage.getItem('ComponentSearchSubject') !== null
         ? localStorage.getItem('ComponentSearchSubject')
         : 'COORDINATES';
+    this.showInactiveProjects =
+      localStorage &&
+      localStorage.getItem('ComponentSearchShowInactiveProjects') !== null
+        ? localStorage.getItem('ComponentSearchShowInactiveProjects') === 'true'
+        : true;
+    this.onlyLatestProjectVersions =
+      localStorage &&
+      localStorage.getItem('ComponentSearchOnlyLatestProjectVersions') !== null
+        ? localStorage.getItem('ComponentSearchOnlyLatestProjectVersions') ===
+          'true'
+        : false;
   },
   beforeMount() {
     if (this.$route.hash) {
@@ -121,6 +154,24 @@ export default {
         localStorage.setItem('ComponentSearchSubject', this.subject);
       }
     },
+    showInactiveProjects(val) {
+      if (localStorage) {
+        localStorage.setItem(
+          'ComponentSearchShowInactiveProjects',
+          val.toString(),
+        );
+      }
+      this.performSearch();
+    },
+    onlyLatestProjectVersions(val) {
+      if (localStorage) {
+        localStorage.setItem(
+          'ComponentSearchOnlyLatestProjectVersions',
+          val.toString(),
+        );
+      }
+      this.performSearch();
+    },
   },
   methods: {
     createQueryParams: function () {
@@ -153,6 +204,18 @@ export default {
         this.$refs.table.refresh({ silent: true });
       } else {
         let queryParams = this.createQueryParams();
+        const projectFilters = [];
+        if (!this.showInactiveProjects) {
+          projectFilters.push('excludeInactiveProjects=true');
+        }
+        if (this.onlyLatestProjectVersions) {
+          projectFilters.push('onlyLatestProjectVersions=true');
+        }
+        if (projectFilters.length) {
+          queryParams = queryParams
+            ? queryParams + '&' + projectFilters.join('&')
+            : projectFilters.join('&');
+        }
         this.options.url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/identity?${queryParams}`;
         this.$refs.table.refresh({ silent: true });
       }
@@ -207,6 +270,12 @@ export default {
       coordinatesGroup: null,
       coordinatesName: null,
       coordinatesVersion: null,
+      showInactiveProjects: this.showInactiveProjects,
+      onlyLatestProjectVersions: this.onlyLatestProjectVersions,
+      labelIcon: {
+        dataOn: '\u2713',
+        dataOff: '\u2715',
+      },
       subjects: [
         { value: 'COORDINATES', text: this.$t('message.coordinates') },
         { value: 'PACKAGE_URL', text: this.$t('message.package_url') },


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds project filter toggles to component search.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/issues/4570
Backports https://github.com/DependencyTrack/frontend/pull/1505

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
