### PR TITLE
Fix license creation toast message

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -601,6 +601,7 @@
     "legal": "Rechtliches",
     "license": "Lizenz",
     "license_comments": "Lizenzkommentare",
+    "license_created": "Lizenz erstellt",
     "license_expression": "SPDX-Ausdruck",
     "license_group": "Lizenzgruppe",
     "license_group_created": "Lizenzgruppe erstellt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -601,6 +601,7 @@
     "legal": "Legal",
     "license": "License",
     "license_comments": "License Comments",
+    "license_created": "License created",
     "license_expression": "SPDX Expression",
     "license_group": "License group",
     "license_group_created": "License group created",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -601,6 +601,7 @@
     "legal": "Legal",
     "license": "Licencia",
     "license_comments": "Comentarios de licencia",
+    "license_created": "Licencia creada",
     "license_expression": "Expresión SPDX",
     "license_group": "Grupo de licencia",
     "license_group_created": "Grupo de licencia creado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -601,6 +601,7 @@
     "legal": "Légal",
     "license": "Licence",
     "license_comments": "Commentaires sur la licence",
+    "license_created": "Licence créée",
     "license_expression": "Expression SPDX",
     "license_group": "Groupe de licences",
     "license_group_created": "Groupe de licences créé",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -601,6 +601,7 @@
     "legal": "कानूनी",
     "license": "लाइसेंस",
     "license_comments": "लाइसेंस टिप्पणियाँ",
+    "license_created": "लाइसेंस बनाया गया",
     "license_expression": "एसपीडीएक्स अभिव्यक्ति",
     "license_group": "लाइसेंस समूह",
     "license_group_created": "लाइसेंस समूह बनाया गया",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -601,6 +601,7 @@
     "legal": "Legale",
     "license": "Licenza",
     "license_comments": "Commenti sulla licenza",
+    "license_created": "Licenza creata",
     "license_expression": "Espressione SPDX",
     "license_group": "Gruppo di licenze",
     "license_group_created": "Gruppo di licenze creato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -601,6 +601,7 @@
     "legal": "法律上の",
     "license": "ライセンス",
     "license_comments": "ライセンスコメント",
+    "license_created": "ライセンスが作成されました",
     "license_expression": "SPDX 式",
     "license_group": "ライセンスグループ",
     "license_group_created": "ライセンスグループが作成されました",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -601,6 +601,7 @@
     "legal": "Prawny",
     "license": "Licencja",
     "license_comments": "Komentarze licencyjne",
+    "license_created": "Utworzono licencję",
     "license_expression": "Wyrażenie SPDX",
     "license_group": "Grupa licencji",
     "license_group_created": "Utworzono grupę licencji",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -601,6 +601,7 @@
     "legal": "Jurídico",
     "license": "Licença",
     "license_comments": "Comentários sobre licença",
+    "license_created": "Licença criada",
     "license_expression": "Expressão SPDX",
     "license_group": "Grupo de licença",
     "license_group_created": "Grupo de licença criado",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -601,6 +601,7 @@
     "legal": "Jurídico",
     "license": "Licença",
     "license_comments": "Comentários sobre licença",
+    "license_created": "Licença criada",
     "license_expression": "Expressão SPDX",
     "license_group": "Grupo de licença",
     "license_group_created": "Grupo de licença criado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -601,6 +601,7 @@
     "legal": "Юридический",
     "license": "Лицензия",
     "license_comments": "Комментарии к лицензии",
+    "license_created": "Лицензия создана",
     "license_expression": "SPDX выражение",
     "license_group": "Группа лицензий",
     "license_group_created": "Группа лицензий создана",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -601,6 +601,7 @@
     "legal": "Юридичні аспекти",
     "license": "Ліцензія",
     "license_comments": "Коментарі до ліцензії",
+    "license_created": "Ліцензію створено",
     "license_expression": "Вираз SPDX",
     "license_group": "Група ліцензій",
     "license_group_created": "Групу ліцензій створено",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -601,6 +601,7 @@
     "legal": "法律",
     "license": "授權",
     "license_comments": "授權備註",
+    "license_created": "授權已建立",
     "license_expression": "SPDX 表示式",
     "license_group": "授權組",
     "license_group_created": "授權組已建立",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -601,6 +601,7 @@
     "legal": "法律",
     "license": "许可证",
     "license_comments": "许可证备注",
+    "license_created": "许可证已创建",
     "license_expression": "SPDX 表达式",
     "license_group": "许可证组",
     "license_group_created": "许可证组已创建",

--- a/src/views/portfolio/licenses/LicenseAddLicenseModal.vue
+++ b/src/views/portfolio/licenses/LicenseAddLicenseModal.vue
@@ -178,11 +178,11 @@ export default {
           isDeprecatedLicenseId: this.license.isDeprecatedLicenseId,
           seeAlso: this.license.seeAlso,
         })
-        .then((response) => {
+        .then(() => {
           this.$emit('refreshTable');
-          this.$toastr.s(this.$t('message.project_created'));
+          this.$toastr.s(this.$t('message.license_created'));
         })
-        .catch((error) => {
+        .catch(() => {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));
         })
         .finally(() => {


### PR DESCRIPTION
## Description

Fixes #1417.

This updates the add-license modal so a successfully created license shows the license-specific success toast instead of reusing the project creation message.

The change also adds the new `license_created` i18n key across the existing locale files.

## Testing

- `npx eslint src/views/portfolio/licenses/LicenseAddLicenseModal.vue --report-unused-disable-directives`
- `node -e "const fs=require('fs'); for (const f of fs.readdirSync('src/i18n/locales')) { const p='src/i18n/locales/'+f; const data=JSON.parse(fs.readFileSync(p,'utf8')); if (!data.message?.license_created) throw new Error(f+' missing license_created'); } console.log('all locale files contain message.license_created');"`
- `npm run build`

Note: `npm run vue-i18n-extract` currently fails before reporting missing/unused keys with `EISDIR: illegal operation on a directory, read` in `vue-i18n-extract`. Full-repo `npm run eslint` also fails on pre-existing repository-wide lint issues unrelated to this change.
