### PR TITLE
Remove default sort from global vuln audit views

### DIFF
--- a/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
+++ b/src/views/globalAudit/VulnerabilityAuditByOccurrence.vue
@@ -244,7 +244,7 @@ export default {
           title: this.$t('message.vulnerability'),
           field: 'vulnerability.vulnId',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value, row) {
             let url = xssFilters.uriInUnQuotedAttr(
               '../vulnerabilities/' +
                 row.vulnerability.source +
@@ -261,7 +261,7 @@ export default {
           title: this.$t('message.severity'),
           field: 'vulnerability.severity',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               return common.formatSeverityLabel(value);
             }
@@ -271,7 +271,7 @@ export default {
           title: this.$t('message.project_name'),
           field: 'component.projectName',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(_, row) {
             let url = xssFilters.uriInUnQuotedAttr(
               '../projects/' + row.component.project,
             );
@@ -287,7 +287,7 @@ export default {
           title: this.$t('message.component'),
           field: 'component.name',
           sortable: true,
-          formatter: (value, row, index) => {
+          formatter: (value, row) => {
             let url = xssFilters.uriInUnQuotedAttr(
               '../../../components/' + row.component.uuid,
             );
@@ -307,7 +307,7 @@ export default {
           title: this.$t('message.version'),
           field: 'component.version',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value, row) {
             if (row.component.latestVersion) {
               if (row.component.latestVersion !== row.component.version) {
                 return (
@@ -331,7 +331,7 @@ export default {
           title: this.$t('message.cvss_v3'),
           field: 'vulnerability.cvssV3BaseScore',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (value && typeof value === 'number') {
               return value.toFixed(1);
             } else {
@@ -343,7 +343,7 @@ export default {
           title: this.$t('message.cvss_v4'),
           field: 'vulnerability.cvssV4Score',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (Number.isFinite(value)) {
               return value.toFixed(1);
             } else {
@@ -368,7 +368,7 @@ export default {
           field: 'attribution.analyzerIdentity',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(_, row) {
             return common.formatAnalyzerLabel(
               row.attribution.analyzerIdentity,
               row.vulnerability.source,
@@ -383,7 +383,7 @@ export default {
           field: 'vulnerability.published',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               return common.formatTimestamp(value);
             }
@@ -394,7 +394,7 @@ export default {
           field: 'vulnerability.cwes',
           sortable: false,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               let s = '';
               for (let i = 0; i < value.length; i++) {
@@ -413,7 +413,7 @@ export default {
           field: 'vulnerability.cvssV2BaseScore',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (value && typeof value === 'number') {
               return value.toFixed(1);
             } else {
@@ -427,7 +427,7 @@ export default {
           sortable: true,
           visible: false,
           class: 'tight',
-          formatter(value, row, index) {
+          formatter(value) {
             return value === true ? '<i class="fa fa-check-square-o" />' : '';
           },
         },
@@ -435,7 +435,7 @@ export default {
           title: this.$t('message.attributed_on'),
           field: 'attribution.attributedOn',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             return xssFilters.inHTMLData(common.formatTimestamp(value));
           },
         },
@@ -460,18 +460,12 @@ export default {
                 localStorage.getItem('VulnerabilityAuditByOccurrencePageSize'),
               )
             : 10,
-        sortName:
-          localStorage &&
-          localStorage.getItem('VulnerabilityAuditByOccurrenceSortName') !==
-            null
-            ? localStorage.getItem('VulnerabilityAuditByOccurrenceSortName')
-            : 'attribution.attributedOn',
-        sortOrder:
-          localStorage &&
-          localStorage.getItem('VulnerabilityAuditByOccurrenceSortOrder') !==
-            null
-            ? localStorage.getItem('VulnerabilityAuditByOccurrenceSortOrder')
-            : 'desc',
+        sortName: localStorage
+          ? localStorage.getItem('VulnerabilityAuditByOccurrenceSortName')
+          : null,
+        sortOrder: localStorage
+          ? localStorage.getItem('VulnerabilityAuditByOccurrenceSortOrder')
+          : null,
         icons: {
           refresh: 'fa-refresh',
         },
@@ -480,7 +474,7 @@ export default {
           return res;
         },
         url: this.apiUrl(),
-        onPageChange: (number, size) => {
+        onPageChange: (_, size) => {
           if (localStorage) {
             localStorage.setItem(
               'VulnerabilityAuditByOccurrencePageSize',

--- a/src/views/globalAudit/VulnerabilityAuditGroupedByVulnerability.vue
+++ b/src/views/globalAudit/VulnerabilityAuditGroupedByVulnerability.vue
@@ -196,7 +196,7 @@ export default {
           title: this.$t('message.vulnerability'),
           field: 'vulnerability.vulnId',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value, row) {
             let url = xssFilters.uriInUnQuotedAttr(
               '../vulnerabilities/' +
                 row.vulnerability.source +
@@ -213,7 +213,7 @@ export default {
           title: this.$t('message.severity'),
           field: 'vulnerability.severity',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               return common.formatSeverityLabel(value);
             }
@@ -223,7 +223,7 @@ export default {
           title: this.$t('message.cvss_v3'),
           field: 'vulnerability.cvssV3BaseScore',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (value && typeof value === 'number') {
               return value.toFixed(1);
             } else {
@@ -235,7 +235,7 @@ export default {
           title: this.$t('message.cvss_v4'),
           field: 'vulnerability.cvssV4Score',
           sortable: true,
-          formatter(value, row, index) {
+          formatter(value) {
             if (Number.isFinite(value)) {
               return value.toFixed(1);
             } else {
@@ -258,7 +258,7 @@ export default {
           field: 'attribution.analyzerIdentity',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(_, row) {
             return common.formatAnalyzerLabel(
               row.attribution.analyzerIdentity,
               row.vulnerability.source,
@@ -273,7 +273,7 @@ export default {
           field: 'vulnerability.published',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               return common.formatTimestamp(value);
             }
@@ -284,7 +284,7 @@ export default {
           field: 'vulnerability.cwes',
           sortable: false,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (typeof value !== 'undefined') {
               let s = '';
               for (let i = 0; i < value.length; i++) {
@@ -303,7 +303,7 @@ export default {
           field: 'vulnerability.cvssV2BaseScore',
           sortable: true,
           visible: false,
-          formatter(value, row, index) {
+          formatter(value) {
             if (value && typeof value === 'number') {
               return value.toFixed(1);
             } else {
@@ -334,24 +334,16 @@ export default {
                 ),
               )
             : 10,
-        sortName:
-          localStorage &&
-          localStorage.getItem(
-            'VulnerabilityAuditGroupedByVulnerabilitySortName',
-          ) !== null
-            ? localStorage.getItem(
-                'VulnerabilityAuditGroupedByVulnerabilitySortName',
-              )
-            : 'vulnerability.affectedProjectCount',
-        sortOrder:
-          localStorage &&
-          localStorage.getItem(
-            'VulnerabilityAuditGroupedByVulnerabilitySortOrder',
-          ) !== null
-            ? localStorage.getItem(
-                'VulnerabilityAuditGroupedByVulnerabilitySortOrder',
-              )
-            : 'desc',
+        sortName: localStorage
+          ? localStorage.getItem(
+              'VulnerabilityAuditGroupedByVulnerabilitySortName',
+            )
+          : null,
+        sortOrder: localStorage
+          ? localStorage.getItem(
+              'VulnerabilityAuditGroupedByVulnerabilitySortOrder',
+            )
+          : null,
         icons: {
           refresh: 'fa-refresh',
         },
@@ -360,7 +352,7 @@ export default {
           return res;
         },
         url: this.apiUrl(),
-        onPageChange: (number, size) => {
+        onPageChange: (_, size) => {
           if (localStorage) {
             localStorage.setItem(
               'VulnerabilityAuditGroupedByVulnerabilityPageSize',


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes default sort from global vuln audit views.

The defaults were particularly expensive to compute. Doing these sorts should be an explicit decision, not the default.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
