### PR TITLE
Remove tabindex from non-interactive scrollbar elements

### DIFF
--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -212,16 +212,15 @@ export default {
       }
     },
 
-	removeScrollbarTabindex() {
-		  document.querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
+  removeScrollbarTabindex() {
+	  document.querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
 		    .forEach(el => el.removeAttribute('tabindex'));
 	},
-  },
+  
   mounted() {
 	  this.$nextTick(() => {
 		    this.removeScrollbarTabindex();
 	  });
-	  ``
 
     if (this.$dtrack && this.$dtrack.version.includes('SNAPSHOT')) {
       this.$root.$emit('bv::show::modal', 'snapshotModal');
@@ -246,10 +245,10 @@ export default {
       }
     });
   },
-	updated() {
-		  this.$nextTick(() => {
-			      this.removeScrollbarTabindex();
-			    });
+  updated() {
+	this.$nextTick(() => {
+	this.removeScrollbarTabindex();
+		});
 	},
   computed: {
     name() {

--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -216,7 +216,7 @@ export default {
 	  document.querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
 		    .forEach(el => el.removeAttribute('tabindex'));
 	},
-  
+
   mounted() {
 	  this.$nextTick(() => {
 		    this.removeScrollbarTabindex();

--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -212,15 +212,17 @@ export default {
       }
     },
 
-  removeScrollbarTabindex() {
-	  document.querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
-		    .forEach(el => el.removeAttribute('tabindex'));
-	},
-
+    removeScrollbarTabindex() {
+      document
+        .querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
+        .forEach((el) => el.removeAttribute('tabindex'));
+    },
+  },
   mounted() {
-	  this.$nextTick(() => {
-		    this.removeScrollbarTabindex();
-	  });
+    this.$nextTick(() => {
+      this.removeScrollbarTabindex();
+    });
+    ``;
 
     if (this.$dtrack && this.$dtrack.version.includes('SNAPSHOT')) {
       this.$root.$emit('bv::show::modal', 'snapshotModal');
@@ -246,10 +248,10 @@ export default {
     });
   },
   updated() {
-	this.$nextTick(() => {
-	this.removeScrollbarTabindex();
-		});
-	},
+    this.$nextTick(() => {
+      this.removeScrollbarTabindex();
+    });
+  },
   computed: {
     name() {
       return this.$route.name;

--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -211,8 +211,18 @@ export default {
         ];
       }
     },
+
+	removeScrollbarTabindex() {
+		  document.querySelectorAll('.ps__scrollbar-x, .ps__scrollbar-y')
+		    .forEach(el => el.removeAttribute('tabindex'));
+	},
   },
   mounted() {
+	  this.$nextTick(() => {
+		    this.removeScrollbarTabindex();
+	  });
+	  ``
+
     if (this.$dtrack && this.$dtrack.version.includes('SNAPSHOT')) {
       this.$root.$emit('bv::show::modal', 'snapshotModal');
     }
@@ -236,6 +246,11 @@ export default {
       }
     });
   },
+	updated() {
+		  this.$nextTick(() => {
+			      this.removeScrollbarTabindex();
+			    });
+	},
   computed: {
     name() {
       return this.$route.name;


### PR DESCRIPTION

### Description

Removes tabindex="0" from non-interactive scrollbar elements (.ps__scrollbar-x and .ps__scrollbar-y).

These elements are invisible and do not provide any functionality, but were still receiving keyboard focus, resulting in blank focus stops for users navigating via keyboard or assistive technologies.


### Addressed Issue

Closes #1596

### Additional Details

The fix removes tabindex from the scrollbar elements using a Vue lifecycle approach, ensuring they are no longer included in the tab order.

This solution ensures that only interactive and meaningful elements remain focusable, improving keyboard navigation and accessibility.

The approach was chosen to avoid modifying third-party library code directly and instead handle the issue within the component lifecycle.

Verified by:
- Testing keyboard navigation flow:
  Admin → Sidebar Minimizer → Home
- Confirming removal of blank focus stops
- Inspecting document.activeElement to ensure only valid interactive elements receive focus


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly