### PR TITLE
Backport: Fix getTabFromRoute erroneously considering URL query params

### DIFF
--- a/src/views/globalAudit/VulnerabilityAudit.vue
+++ b/src/views/globalAudit/VulnerabilityAudit.vue
@@ -67,7 +67,7 @@ export default {
       }
     },
     getTabFromRoute: function () {
-      let pattern = new RegExp('/vulnerabilityAudit\\/([^\\/]*)', 'gi');
+      let pattern = new RegExp('/vulnerabilityAudit\\/([^\\/?#]*)', 'gi');
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());
       tab && tab[1] && tab[1].toLowerCase() === 'grouped'
         ? (this.tabIndex = 1)

--- a/src/views/policy/PolicyManagement.vue
+++ b/src/views/policy/PolicyManagement.vue
@@ -93,7 +93,7 @@ export default {
       }
     },
     getTabFromRoute: function () {
-      let pattern = new RegExp('/policy\/([^\\/]*)', 'gi');
+      let pattern = new RegExp('/policy\/([^\\/?#]*)', 'gi');
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());
       return this.$refs[tab && tab[1] ? tab[1].toLowerCase() : 'policies'];
     },

--- a/src/views/portfolio/licenses/License.vue
+++ b/src/views/portfolio/licenses/License.vue
@@ -165,7 +165,7 @@ export default {
     },
     getTabFromRoute: function () {
       let pattern = new RegExp(
-        '/licenses\\/' + this.licenseId + '\\/([^\\/]*)',
+        '/licenses\\/' + this.licenseId + '\\/([^\\/?#]*)',
         'gi',
       );
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());

--- a/src/views/portfolio/projects/Component.vue
+++ b/src/views/portfolio/projects/Component.vue
@@ -280,7 +280,7 @@ export default {
     },
     getTabFromRoute: function () {
       let pattern = new RegExp(
-        '/components\\/' + this.uuid + '\\/([^\\/]*)',
+        '/components\\/' + this.uuid + '\\/([^\\/?#]*)',
         'gi',
       );
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -640,7 +640,7 @@ export default {
     },
     getTabFromRoute: function () {
       let pattern = new RegExp(
-        '/projects\\/' + this.uuid + '\\/([^\\/]*)',
+        '/projects\\/' + this.uuid + '\\/([^\\/?#]*)',
         'gi',
       );
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -544,7 +544,7 @@ export default {
           this.source +
           '\\/' +
           encodeURIComponent(this.vulnId) +
-          '\\/([^\\/]*)',
+          '\\/([^\\/?#]*)',
         'gi',
       );
       let tab = pattern.exec(this.$route.fullPath.toLowerCase());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fix getTabFromRoute erroneously considering URL query params.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #1592 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

Some views "persist" search parameters in the URL query, while simultaneously watching the URL for which tab to show. The latter erroneously considered URL query params, such that typing in a search field would cause `getTabFromRoute` to yield no existing tab, which then caused the view to "snap" back to the default tab.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
