### PR TITLE
Backport: Fix spelling of CANCELLED workflow run status

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -316,7 +316,7 @@
     "workflow_event_child_run_created": "Child Run Created",
     "workflow_event_child_run_failed": "Child Run Failed",
     "workflow_event_external_event_received": "External Event Received",
-    "workflow_event_run_canceled": "Run Canceled",
+    "workflow_event_run_canceled": "Run Cancelled",
     "workflow_event_run_completed": "Run Completed",
     "workflow_event_run_created": "Run Created",
     "workflow_event_run_resumed": "Run Resumed",

--- a/src/views/administration/workflows/WorkflowRunDetail.vue
+++ b/src/views/administration/workflows/WorkflowRunDetail.vue
@@ -349,7 +349,7 @@ const CollapsibleJson = {
   `,
 };
 
-const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'CANCELED'];
+const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'CANCELLED'];
 const POLL_INTERVAL_MS = 5000;
 const EVENT_LIMIT = 10;
 const POLL_LIMIT = 50;
@@ -557,7 +557,7 @@ export default {
     },
     statusIcon(status) {
       const icons = {
-        CANCELED: 'fa-ban',
+        CANCELLED: 'fa-ban',
         FAILED: 'fa-fire',
         SUSPENDED: 'fa-pause',
         RUNNING: 'fa-play',
@@ -568,7 +568,7 @@ export default {
     },
     statusVariant(status) {
       const variants = {
-        CANCELED: 'warning',
+        CANCELLED: 'warning',
         FAILED: 'danger',
         RUNNING: 'secondary',
         COMPLETED: 'success',

--- a/src/views/administration/workflows/WorkflowRunList.vue
+++ b/src/views/administration/workflows/WorkflowRunList.vue
@@ -126,7 +126,7 @@ export default {
       sortBy: null,
       sortDirection: null,
       statusOptions: [
-        { value: 'CANCELED', text: this.$t(`message.status_canceled`) },
+        { value: 'CANCELLED', text: this.$t(`message.status_canceled`) },
         { value: 'COMPLETED', text: this.$t(`message.status_completed`) },
         { value: 'CREATED', text: this.$t(`message.status_created`) },
         { value: 'FAILED', text: this.$t(`message.status_failed`) },
@@ -167,7 +167,7 @@ export default {
           formatter: (value) => {
             let iconName = 'fa-question';
             let textVariant = 'primary';
-            if (value === 'CANCELED') {
+            if (value === 'CANCELLED') {
               iconName = 'fa-ban';
               textVariant = 'warning';
             } else if (value === 'FAILED') {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fix spelling of CANCELLED workflow run status.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #1598 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
