### PR TITLE
Add visible focus indicators for interactive elements

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -514,3 +514,19 @@ td a.detail-icon {
   float: right;
   padding-top: 0.3rem;
 }
+
+.navbar-toggler:focus-visible {
+      outline: 3px solid #66ccff !important;
+          outline-offset: 2px;
+}
+
+.sidebar-nav a:focus-visible,
+.nav-link:focus-visible {
+  outline: 3px solid #66ccff !important;
+  outline-offset: 2px;
+                }
+
+.sidebar-minimizer:focus-visible {
+  outline: 3px solid #66ccff !important;
+  outline-offset: 2px;
+  }


### PR DESCRIPTION

### Description

Adds visible focus indicators for interactive elements using :focus-visible and high-contrast outlines.

This ensures that keyboard users can clearly identify which element is currently focused, improving accessibility and usability across the application.


### Addressed Issue

Closes #1603


### Additional Details

The issue was caused by CSS overriding or removing default browser focus indicators (e.g., outline: none), resulting in invisible focus states for certain elements.

The fix introduces explicit :focus-visible styles using a high-contrast 3px outline and outline-offset to ensure consistent and clearly visible indicators across all affected interactive elements, including the navbar toggle, sidebar navigation items, and sidebar minimizer.

The solution was designed to:
- Restore visibility of focus indicators for keyboard navigation
- Avoid impacting mouse interactions by using :focus-visible
- Override any existing styles that suppress default outlines

Verified by:
- Testing keyboard navigation using the Tab key
- Confirming all interactive elements display a clear and consistent focus outline
- Ensuring no visual regressions or layout issues were introduced

-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
