### PR TITLE
Backport: Fix rendering of expander icons for nested project hierarchies

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -162,21 +162,36 @@ export default {
           });
         }
         this.$refs.table.getData().forEach((project) => {
-          if (project.fetchedChildren || project.checkedHasChildren) {
+          // Expander is rendered natively by treegrid when children are
+          // already loaded. No extra logic needed.
+          if (project.fetchedChildren) {
+            return;
+          }
+
+          const renderExpander = () => {
+            this.$refs.table.$table
+              .find('tbody')
+              .find('tr.treegrid-' + project.id.toString())
+              .addClass('treegrid-collapsed')
+              .treegrid('renderExpander');
+          };
+
+          // Pre-flight result already known to be positive. Just render
+          // the expander, since the tbody was just rebuilt and dropped it.
+          if (project.matchesChildSearch) {
+            renderExpander();
+            return;
+          }
+
+          if (project.checkedHasChildren) {
             return;
           }
           project.checkedHasChildren = true;
 
           this.hasMatchingChildren(project).then((doesHaveMatchingChildren) => {
+            project.matchesChildSearch = doesHaveMatchingChildren;
             if (doesHaveMatchingChildren) {
-              this.$refs.table.$table
-                .find('tbody')
-                .find('tr.treegrid-' + project.id.toString())
-                .addClass('treegrid-collapsed');
-              this.$refs.table.$table
-                .find('tbody')
-                .find('tr.treegrid-' + project.id.toString())
-                .treegrid('renderExpander');
+              renderExpander();
             }
           });
         });
@@ -207,7 +222,7 @@ export default {
     },
     hasMatchingChildren: function (project) {
       if (!project.hasChildren) {
-        return new Promise(() => false);
+        return Promise.resolve(false);
       }
 
       // Perform a pre-flight search if there is at least one


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes rendering of expander icons for nested project hierarchies.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #1617
Backports #1618 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
