### PR TITLE
Fix/frontend accessibility 1614

### DIFF
--- a/src/forms/BInputGroupFormInput.vue
+++ b/src/forms/BInputGroupFormInput.vue
@@ -9,6 +9,13 @@
       <b-input-group-prepend v-if="icon"
         ><b-input-group-text><i :class="icon"></i></b-input-group-text
       ></b-input-group-prepend>
+      <span
+        v-if="tooltip"
+        :id="`${id}-tooltip`"
+        class="sr-only"
+      >
+        {{ tooltip }}
+      </span>
       <b-form-input
         :id="`${id}-input`"
         :type="type"
@@ -21,6 +28,7 @@
         :required="isRequired"
         :readonly="readonly"
         :disabled="isDisabled"
+        :aria-describedby="tooltip ? `${id}-tooltip` : null"
         v-on="inputListeners"
         v-on:blur="hadFocus = true"
         trim

--- a/src/forms/BInputGroupFormSelect.vue
+++ b/src/forms/BInputGroupFormSelect.vue
@@ -9,7 +9,13 @@
       <b-input-group-prepend v-if="icon"
         ><b-input-group-text><i :class="icon"></i></b-input-group-text
       ></b-input-group-prepend>
-
+      <span
+        v-if="tooltip"
+        :id="`${id}-tooltip`"
+        class="sr-only"
+      >
+        {{ tooltip }}
+      </span>
       <b-form-select
         :id="`${id}-input`"
         v-model="value"
@@ -19,6 +25,7 @@
         :required="isRequired"
         :state="feedbackState()"
         :class="inputClasses"
+        :aria-describedby="tooltip ? `${id}-tooltip` : null"
         v-on="inputListeners"
         v-on:blur="hadFocus = true"
       />


### PR DESCRIPTION
### Description

Adds accessibility support for form field tooltips by associating additional instructions with their corresponding inputs using `aria-describedby`.

This ensures that tooltip content provided on shared form input and select components is also exposed to assistive technologies such as screen readers.

### Addressed Issue

#1614

### Additional Details

The affected form components previously displayed tooltip information visually only. Screen readers could not reliably associate the additional instructions with the related form controls.

The fix was implemented in the shared form components so existing usages that provide tooltip content automatically expose the description without requiring changes in individual views or forms.

The visual tooltip behavior is preserved while adding the hidden accessible description required for screen readers.

Tested on Linux using Firefox and Orca screen reader to verify that the tooltip descriptions are announced when focusing the affected form fields.

### Checklist

* [x] I have read and understand the [[contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] This PR introduces new or alters existing behavior, and I have updated the [[documentation](https://github.com/DependencyTrack/docs)](https://github.com/DependencyTrack/docs) accordingly