### PR TITLE
feat(policy): add matches/no match operators and syntax tooltip for Vulnerability ID conditions

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1151,6 +1151,7 @@
     "vulnerability_updated_desc": "The date the vulnerability record was last updated",
     "vulnerability_vuln_id": "Vulnerability ID",
     "vulnerability_vuln_id_desc": "The identifier which uniquely identifies this vulnerability within the same source",
+    "vulnerability_id_pattern_tooltip": "Use * as wildcard (e.g., CVE-2024-* or MAL-*) or regular expressions (e.g., ^CVE-202[34]-.*)",
     "vulnerable": "Vulnerable",
     "vulnerable_components": "Vulnerable Components",
     "vulnerable_projects": "Vulnerable Projects",

--- a/src/views/policy/PolicyCondition.vue
+++ b/src/views/policy/PolicyCondition.vue
@@ -328,6 +328,12 @@ export default {
         { value: 'MATCHES', text: this.$t('operator.matches') },
         { value: 'NO_MATCH', text: this.$t('operator.no_match') },
       ],
+      objectAndRegexOperators: [
+        { value: 'IS', text: this.$t('operator.is') },
+        { value: 'IS_NOT', text: this.$t('operator.is_not') },
+        { value: 'MATCHES', text: this.$t('operator.matches') },
+        { value: 'NO_MATCH', text: this.$t('operator.no_match') },
+      ],
       numericOperators: [
         { value: 'NUMERIC_GREATER_THAN', text: '>' },
         { value: 'NUMERIC_LESS_THAN', text: '<' },
@@ -503,7 +509,7 @@ export default {
           this.operators = this.listOperators;
           break;
         case 'VULNERABILITY_ID':
-          this.operators = this.objectOperators;
+          this.operators = this.objectAndRegexOperators;
           break;
         case 'VERSION_DISTANCE':
           this.operators = this.numericOperators;
@@ -744,6 +750,11 @@ export default {
       switch (this.subject) {
         case 'AGE':
           return this.$t('message.age_tooltip');
+        case 'VULNERABILITY_ID':
+          if (this.operator === 'MATCHES' || this.operator === 'NO_MATCH') {
+            return this.$t('message.vulnerability_id_pattern_tooltip');
+          }
+          return '';
         default:
           return '';
       }


### PR DESCRIPTION
### Description

The Vulnerability ID policy subject currently offers only the `Is` / `Is not` operators in the condition editor. This change also exposes the `Matches` and `Does not match` operators for that subject, and displays a tooltip on the value input explaining the supported wildcard (`*`) and regular-expression syntax when either operator is selected.

This is the frontend counterpart to the backend change that adds `MATCHES` / `NO_MATCH` evaluation for `VULNERABILITY_ID` conditions (DependencyTrack/dependency-track). Without it, the operators are accepted by the API but not selectable in the UI.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/pull/6629

### Additional Details

Implementation adds an `objectAndRegexOperators` set (IS / IS_NOT / MATCHES / NO_MATCH) used by the `VULNERABILITY_ID` subject, and extends `valueInputTooltip()` to return a `vulnerability_id_pattern_tooltip` string for the MATCHES / NO_MATCH operators. The `operator.matches` and `operator.no_match` labels already exist; only the new tooltip key was added (English locale).

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly