### PR TITLE
Prevent duplicate downloads on export/download buttons

### DIFF
--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -35,10 +35,14 @@
         }}</b-tooltip>
         <b-dropdown
           variant="outline-primary"
+          :disabled="isDownloadingBom"
           v-permission="PERMISSIONS.VIEW_PORTFOLIO"
         >
           <template #button-content>
-            <span class="fa fa-download"></span>
+            <span
+              class="fa"
+              :class="isDownloadingBom ? 'fa-spinner fa-spin' : 'fa-download'"
+            ></span>
             {{ $t('message.download_bom') }}
           </template>
           <b-dropdown-item @click="downloadBom('inventory')" href="#">{{
@@ -52,10 +56,14 @@
         </b-dropdown>
         <b-dropdown
           variant="outline-primary"
+          :disabled="isDownloadingTable"
           v-permission="PERMISSIONS.VIEW_PORTFOLIO"
         >
           <template #button-content>
-            <span class="fa fa-download"></span>
+            <span
+              class="fa"
+              :class="isDownloadingTable ? 'fa-spinner fa-spin' : 'fa-download'"
+            ></span>
             {{ $t('message.download_component') }}
           </template>
           <b-dropdown-item @click="downloadTable('csv')" href="#">{{
@@ -151,6 +159,8 @@ export default {
   },
   data() {
     return {
+      isDownloadingBom: false,
+      isDownloadingTable: false,
       labelIcon: {
         dataOn: '\u2713',
         dataOff: '\u2715',
@@ -410,6 +420,10 @@ export default {
       this.$refs.table.uncheckAll();
     },
     downloadBom: function (data) {
+      if (this.isDownloadingBom) {
+        return;
+      }
+      this.isDownloadingBom = true;
       let url = `${this.$api.BASE_URL}/${this.$api.URL_BOM}/cyclonedx/project/${this.uuid}`;
       this.axios
         .request({
@@ -438,6 +452,9 @@ export default {
           link.setAttribute('download', filename);
           document.body.appendChild(link);
           link.click();
+        })
+        .finally(() => {
+          this.isDownloadingBom = false;
         });
     },
     buildTableFile: function (json, fileType) {
@@ -469,8 +486,16 @@ export default {
       }
     },
     downloadTable: async function (fileType) {
-      const result = await this.downloadTableJson();
-      this.buildTableFile(result, fileType);
+      if (this.isDownloadingTable) {
+        return;
+      }
+      this.isDownloadingTable = true;
+      try {
+        const result = await this.downloadTableJson();
+        this.buildTableFile(result, fileType);
+      } finally {
+        this.isDownloadingTable = false;
+      }
     },
     downloadTableJson: async function () {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.uuid}?limit=1000000&offset=0`;

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -25,13 +25,18 @@
         id="export-vex-button"
         size="md"
         variant="outline-primary"
+        :disabled="isExportingVex"
         @click="downloadVex()"
         v-permission:or="[
           PERMISSIONS.VIEW_VULNERABILITY,
           PERMISSIONS.VULNERABILITY_ANALYSIS,
         ]"
       >
-        <span class="fa fa-download"></span> {{ $t('message.export_vex') }}
+        <span
+          class="fa"
+          :class="isExportingVex ? 'fa-spinner fa-spin' : 'fa-download'"
+        ></span>
+        {{ $t('message.export_vex') }}
       </b-button>
       <b-tooltip target="export-vex-button" triggers="hover focus">{{
         $t('message.export_vex_tooltip')
@@ -41,13 +46,18 @@
         id="export-vdr-button"
         size="md"
         variant="outline-primary"
+        :disabled="isExportingVdr"
         @click="downloadVdr()"
         v-permission:or="[
           PERMISSIONS.VIEW_VULNERABILITY,
           PERMISSIONS.VULNERABILITY_ANALYSIS,
         ]"
       >
-        <span class="fa fa-download"></span> {{ $t('message.export_vdr') }}
+        <span
+          class="fa"
+          :class="isExportingVdr ? 'fa-spinner fa-spin' : 'fa-download'"
+        ></span>
+        {{ $t('message.export_vdr') }}
       </b-button>
       <b-tooltip target="export-vdr-button" triggers="hover focus">{{
         $t('message.export_vdr_tooltip')
@@ -149,6 +159,8 @@ export default {
   data() {
     return {
       showSuppressedFindings: this.showSuppressedFindings,
+      isExportingVex: false,
+      isExportingVdr: false,
       labelIcon: {
         dataOn: '\u2713',
         dataOff: '\u2715',
@@ -438,6 +450,10 @@ export default {
       return url;
     },
     downloadVex: function () {
+      if (this.isExportingVex) {
+        return;
+      }
+      this.isExportingVex = true;
       let url = `${this.$api.BASE_URL}/${this.$api.URL_VEX}/cyclonedx/project/${this.uuid}`;
       this.axios
         .request({
@@ -464,9 +480,16 @@ export default {
           link.setAttribute('download', filename);
           document.body.appendChild(link);
           link.click();
+        })
+        .finally(() => {
+          this.isExportingVex = false;
         });
     },
     downloadVdr: function () {
+      if (this.isExportingVdr) {
+        return;
+      }
+      this.isExportingVdr = true;
       let url = `${this.$api.BASE_URL}/${this.$api.URL_BOM}/cyclonedx/project/${this.uuid}`;
       this.axios
         .request({
@@ -495,6 +518,9 @@ export default {
           link.setAttribute('download', filename);
           document.body.appendChild(link);
           link.click();
+        })
+        .finally(() => {
+          this.isExportingVdr = false;
         });
     },
     reAnalyze: function (data) {


### PR DESCRIPTION
### Description

Export/download buttons started a new download on every click with no
in-progress guard, so clicking (or double-clicking) while a download was
already running triggered multiple simultaneous requests and duplicate file
downloads. This affected the project Findings view (Export VEX, Export VDR)
and the project Components view (Download BOM — inventory / with-vulnerabilities,
and Download component — CSV).

Each handler now sets an in-progress flag with a guarded early return, disables
the corresponding button/dropdown and shows a spinner while the export runs, and
resets the flag in a `finally()` block so the control re-enables whether the
download succeeds or fails.

### Addressed Issue

fixes #1658

### Additional Details

The frontend project has no component unit-test harness, so this was verified
manually: with the Network tab open (throttled to Slow 3G to widen the window),
rapid/double clicks on each export control now send only one request and produce
a single download, and the control re-enables after completion or error. Verified
on the Findings (VEX/VDR) and Components (BOM/CSV) views.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~