### PR TITLE
feat: add "only latest versions" filter to project list

### DIFF
--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -23,6 +23,16 @@
         $t('message.show_inactive_projects')
       }}</span>
       <c-switch
+        style="margin-left: 1rem; margin-right: 0.5rem"
+        id="onlyLatestVersions"
+        color="primary"
+        v-model="onlyLatestVersions"
+        label
+        v-bind="labelIcon"
+      /><span class="text-muted">{{
+        $t('message.only_latest_project_versions')
+      }}</span>
+      <c-switch
         @click.native="saveViewState"
         style="margin-left: 1rem; margin-right: 0.5rem"
         id="showFlatView"
@@ -83,6 +93,11 @@ export default {
       localStorage && localStorage.getItem('ProjectListShowFlatView') !== null
         ? localStorage.getItem('ProjectListShowFlatView') === 'true'
         : false;
+    this.onlyLatestVersions =
+      localStorage &&
+      localStorage.getItem('ProjectListOnlyLatestVersions') !== null
+        ? localStorage.getItem('ProjectListOnlyLatestVersions') === 'true'
+        : false;
   },
   methods: {
     initializeProjectCreateProjectModal: function () {
@@ -102,6 +117,9 @@ export default {
       };
       if (this.showInactiveProjects === false) {
         queryParams['active'] = true;
+      }
+      if (this.onlyLatestVersions === true) {
+        queryParams['onlyLatestVersions'] = true;
       }
       let tag = this.$route.query.tag;
       if (tag) {
@@ -256,6 +274,17 @@ export default {
       this.currentPage = 1;
       this.refreshTable();
     },
+    onlyLatestVersions() {
+      if (localStorage) {
+        localStorage.setItem(
+          'ProjectListOnlyLatestVersions',
+          this.onlyLatestVersions.toString(),
+        );
+      }
+      this.$refs.table.showLoading();
+      this.currentPage = 1;
+      this.refreshTable();
+    },
     showFlatView() {
       if (localStorage) {
         localStorage.setItem(
@@ -273,6 +302,7 @@ export default {
   data() {
     return {
       showInactiveProjects: this.showInactiveProjects,
+      onlyLatestVersions: this.onlyLatestVersions,
       showFlatView: this.showFlatView,
       isSearching: false,
       savedViewState: null,


### PR DESCRIPTION

### Description

Adds a toolbar toggle to the projects page that sends onlyLatestVersions=true to the concise project listing endpoint, as the frontend counterpart to DependencyTrack/dependency-track#6823. The toggle state is persisted in localStorage, mirroring the existing "show inactive projects" filter.

### Addressed Issue

Partially addresses https://github.com/DependencyTrack/frontend/issues/1165


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
