### PR TITLE
Add UI for durable component license curation: audit panel, component policies, read-only imported components

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Betriebssystem",
     "component_package_url_desc": "Für Bibliotheken und Frameworks ist eine gültige Paket-URL erforderlich. PURL-Syntax: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "Plattform",
+    "component_policies": null,
     "component_properties": "Komponenteneigenschaften",
     "component_search": "Komponentensuche",
     "component_spdx_license_desc": "Gibt die SPDX-Lizenz-ID der Komponente an",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -489,6 +489,7 @@
     "component_operating_system": "Operating system",
     "component_package_url_desc": "A Valid Package URL is required for libraries and frameworks. PURL syntax: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "Platform",
+    "component_policies": "Component Policies",
     "component_properties": "Component Properties",
     "component_search": "Component Search",
     "component_spdx_license_desc": "Specifies the SPDX license ID of the component",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Sistema operativo",
     "component_package_url_desc": "Se requiere una URL de paquete válida para bibliotecas y marcos. Sintaxis PURL: paquete:tipo/espacio de nombres/nombre@versión?calificadores#subruta",
     "component_platform": "Plataforma",
+    "component_policies": null,
     "component_properties": "Propiedades de los componentes",
     "component_search": "Búsqueda de componentes",
     "component_spdx_license_desc": "Especifica el ID de licencia SPDX del componente.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Système d'exploitation",
     "component_package_url_desc": "Une PackageURL valide est requise pour les bibliothèques et les frameworks. Syntaxe PURL : pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "Plate-forme",
+    "component_policies": null,
     "component_properties": "Propriétés des composants",
     "component_search": "Recherche de composants",
     "component_spdx_license_desc": "Spécifie l'ID de licence SPDX du composant",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -488,6 +488,7 @@
     "component_operating_system": "ऑपरेटिंग सिस्टम",
     "component_package_url_desc": "लाइब्रेरीज़ और फ़्रेमवर्क के लिए एक मान्य पैकेज URL आवश्यक है। PURL सिंटैक्स: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "प्लैटफ़ॉर्म",
+    "component_policies": null,
     "component_properties": "घटक गुण",
     "component_search": "घटक खोज",
     "component_spdx_license_desc": "घटक की SPDX लाइसेंस आईडी निर्दिष्ट करता है",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Sistema operativo",
     "component_package_url_desc": "Per librerie e framework è richiesto un URL del pacchetto valido. Sintassi PURL: pkg:tipo/spazio dei nomi/nome@versione?qualificatori#sottopercorso",
     "component_platform": "Piattaforma",
+    "component_policies": null,
     "component_properties": "Proprietà del componente",
     "component_search": "Ricerca componente",
     "component_spdx_license_desc": "Specifica l'ID della licenza SPDX del componente",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -488,6 +488,7 @@
     "component_operating_system": "オペレーティング システム",
     "component_package_url_desc": "ライブラリとフレームワークには有効なパッケージ URL が必要です。PURL 構文: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "プラットフォーム",
+    "component_policies": null,
     "component_properties": "コンポーネントのプロパティ",
     "component_search": "コンポーネント検索",
     "component_spdx_license_desc": "コンポーネントのSPDXライセンスIDを指定します",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -489,6 +489,7 @@
     "component_operating_system": "운영체제",
     "component_package_url_desc": "라이브러리와 프레임워크에는 유효한 Package URL이 필요합니다. PURL 문법: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "플랫폼",
+    "component_policies": null,
     "component_properties": "컴포넌트 속성",
     "component_search": "컴포넌트 검색",
     "component_spdx_license_desc": "컴포넌트의 SPDX 라이선스 ID를 지정합니다",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -488,6 +488,7 @@
     "component_operating_system": "System operacyjny",
     "component_package_url_desc": "W przypadku bibliotek i struktur wymagany jest prawidłowy adres URL pakietu. Składnia PURL: pkg:typ/przestrzeń nazw/nazwa@wersja?kwalifikatory#podścieżka",
     "component_platform": "Platforma",
+    "component_policies": null,
     "component_properties": "Właściwości komponentu",
     "component_search": "Wyszukiwanie komponentów",
     "component_spdx_license_desc": "Określa identyfikator licencji SPDX komponentu",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Sistema operacional",
     "component_package_url_desc": "Um URL de pacote válido é necessário para bibliotecas e estruturas. Sintaxe PURL: pkg:tipo/namespace/nome@versão?qualificadores#subcaminho",
     "component_platform": "Plataforma",
+    "component_policies": null,
     "component_properties": "Propriedades do Componente",
     "component_search": "Pesquisa de Componentes",
     "component_spdx_license_desc": "Especifica o ID de licença SPDX do componente",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Sistema operacional",
     "component_package_url_desc": "Um URL de pacote válido é necessário para bibliotecas e estruturas. Sintaxe PURL: pkg:tipo/namespace/nome@versão?qualificadores#subcaminho",
     "component_platform": "Plataforma",
+    "component_policies": null,
     "component_properties": "Propriedades do Componente",
     "component_search": "Pesquisa de Componentes",
     "component_spdx_license_desc": "Especifica o ID de licença SPDX do componente",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Операционная система",
     "component_package_url_desc": "Действительный Package URL требуется для библиотек и фреймворков. Синтаксис PURL: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "Платформа",
+    "component_policies": null,
     "component_properties": "Свойства компонента",
     "component_search": "Поиск компонента",
     "component_spdx_license_desc": "Указывает идентификатор лицензии SPDX компонента",

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -488,6 +488,7 @@
     "component_operating_system": "Операційна система",
     "component_package_url_desc": "Для бібліотек та фреймворків потрібна дійсна URL-адреса пакета. Синтаксис PURL: pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "Платформа",
+    "component_policies": null,
     "component_properties": "Властивості компонента",
     "component_search": "Пошук компонентів",
     "component_spdx_license_desc": "Визначає ідентифікатор ліцензії SPDX компонента",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -488,6 +488,7 @@
     "component_operating_system": "作業系統",
     "component_package_url_desc": "函式庫和框架需要有效的套件 URL。PURL 語法：pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "平台",
+    "component_policies": null,
     "component_properties": "元件屬性",
     "component_search": "元件搜尋",
     "component_spdx_license_desc": "指定元件的 SPDX 授權 ID",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -488,6 +488,7 @@
     "component_operating_system": "操作系统",
     "component_package_url_desc": "库和框架需要有效的包 URL。PURL 语法：pkg:type/namespace/name@version?qualifiers#subpath",
     "component_platform": "平台",
+    "component_policies": null,
     "component_properties": "组件属性",
     "component_search": "组件搜索",
     "component_spdx_license_desc": "指定组件的 SPDX 许可证 ID",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,6 +28,8 @@ const LicenseList = () => import('@/views/portfolio/licenses/LicenseList');
 const PolicyManagement = () => import('@/views/policy/PolicyManagement');
 const VulnerabilityPolicyEditor = () =>
   import('@/views/policy/VulnerabilityPolicyEditor');
+const ComponentPolicyEditor = () =>
+  import('@/views/policy/ComponentPolicyEditor');
 const Project = () => import('@/views/portfolio/projects/Project');
 const PolicyViolationAudit = () => import('@/views/audit/PolicyViolationAudit');
 
@@ -329,6 +331,31 @@ function configRoutes() {
           },
         },
         {
+          path: 'policy/componentPolicies/new',
+          name: 'ComponentPolicyCreate',
+          component: ComponentPolicyEditor,
+          meta: {
+            title: i18n.t('message.policy_management'),
+            i18n: 'message.policy_management',
+            sectionPath: '/policy',
+            sectionName: 'Policy Management',
+            permissions: ['POLICY_MANAGEMENT', 'POLICY_MANAGEMENT_CREATE'],
+          },
+        },
+        {
+          path: 'policy/componentPolicies/:id',
+          name: 'ComponentPolicyEdit',
+          component: ComponentPolicyEditor,
+          props: (route) => ({ policyId: route.params.id }),
+          meta: {
+            title: i18n.t('message.policy_management'),
+            i18n: 'message.policy_management',
+            sectionPath: '/policy',
+            sectionName: 'Policy Management',
+            permissions: ['POLICY_MANAGEMENT', 'POLICY_MANAGEMENT_READ'],
+          },
+        },
+        {
           path: 'policy/vulnerability/new',
           name: 'VulnerabilityPolicyCreate',
           component: VulnerabilityPolicyEditor,
@@ -359,6 +386,7 @@ function configRoutes() {
           alias: [
             'policy/policies',
             'policy/licenseGroups',
+            'policy/componentPolicies',
             'policy/vulnerability',
           ],
           component: PolicyManagement,

--- a/src/views/policy/ComponentPolicyEditor.vue
+++ b/src/views/policy/ComponentPolicyEditor.vue
@@ -290,8 +290,10 @@ export default {
           description: policy.description || '',
           operationMode: policy.enabled ? 'APPLY' : 'DISABLED',
           priority: String(policy.priority),
-          validFrom: policy.validFrom ? policy.validFrom.slice(0, 10) : null,
-          validUntil: policy.validUntil ? policy.validUntil.slice(0, 10) : null,
+          validFrom: policy.valid_from ? policy.valid_from.slice(0, 10) : null,
+          validUntil: policy.valid_until
+            ? policy.valid_until.slice(0, 10)
+            : null,
           condition: policy.condition,
           license: policy.license || '',
           details: policy.details || '',
@@ -310,10 +312,10 @@ export default {
         condition: this.policy.condition,
         license: this.policy.license || null,
         details: this.policy.details || null,
-        validFrom: this.policy.validFrom
+        valid_from: this.policy.validFrom
           ? `${this.policy.validFrom}T00:00:00Z`
           : null,
-        validUntil: this.policy.validUntil
+        valid_until: this.policy.validUntil
           ? `${this.policy.validUntil}T23:59:59Z`
           : null,
       };

--- a/src/views/policy/ComponentPolicyEditor.vue
+++ b/src/views/policy/ComponentPolicyEditor.vue
@@ -1,0 +1,349 @@
+<template>
+  <div
+    class="animated fadeIn"
+    v-permission:or="[
+      PERMISSIONS.POLICY_MANAGEMENT,
+      PERMISSIONS.POLICY_MANAGEMENT_CREATE,
+      PERMISSIONS.POLICY_MANAGEMENT_READ,
+      PERMISSIONS.POLICY_MANAGEMENT_UPDATE,
+    ]"
+  >
+    <b-card>
+      <template #header>
+        <h5 class="mb-0">{{ pageTitle }}</h5>
+      </template>
+
+      <b-row>
+        <b-col sm="6">
+          <b-input-group-form-input
+            id="policy-name"
+            :label="$t('message.name')"
+            input-group-size="mb-3"
+            required="true"
+            v-model="policy.name"
+            lazy="true"
+          />
+          <b-form-group :label="$t('message.description')">
+            <b-form-textarea
+              id="policy-description"
+              v-model="policy.description"
+              rows="3"
+            />
+          </b-form-group>
+          <b-form-group
+            :label="$t('message.policy_operation_mode')"
+            label-for="policy-operation-mode"
+          >
+            <b-form-select
+              id="policy-operation-mode"
+              v-model="policy.operationMode"
+              :options="operationModeOptions"
+            />
+          </b-form-group>
+        </b-col>
+        <b-col sm="6">
+          <b-form-group
+            :label="$t('message.policy_priority')"
+            label-for="policy-priority"
+            class="mb-3"
+          >
+            <div class="d-flex align-items-center">
+              <b-form-input
+                id="policy-priority"
+                type="range"
+                v-model="policy.priority"
+                min="0"
+                max="100"
+                step="1"
+                class="flex-grow-1"
+              />
+              <span
+                class="ml-2 font-weight-bold"
+                style="min-width: 9em; text-align: right; white-space: nowrap"
+                >{{ policy.priority }} - {{ priorityLabel }}</span
+              >
+            </div>
+          </b-form-group>
+          <b-input-group-form-datepicker
+            id="policy-valid-from"
+            :label="$t('message.validFrom')"
+            input-group-size="mb-3"
+            v-model="policy.validFrom"
+          />
+          <b-input-group-form-datepicker
+            id="policy-valid-until"
+            :label="$t('message.validUntil')"
+            input-group-size="mb-3"
+            v-model="policy.validUntil"
+          />
+        </b-col>
+      </b-row>
+
+      <hr />
+      <h6>{{ $t('message.condition') }}</h6>
+      <div class="mb-3">
+        <b-dropdown variant="outline-primary" size="sm">
+          <template #button-content>
+            <i class="fa fa-magic"></i>
+            {{ $t('message.policy_condition_templates') }}
+          </template>
+          <b-dropdown-item
+            v-for="tpl in conditionTemplates"
+            :key="tpl.label"
+            @click="insertTemplate(tpl)"
+          >
+            {{ tpl.label }}
+          </b-dropdown-item>
+        </b-dropdown>
+      </div>
+      <code-mirror-editor
+        ref="conditionEditor"
+        :value="policy.condition"
+        @input="(value) => (policy.condition = value)"
+        :completionSource="celCompletionSource"
+      />
+
+      <hr />
+      <h6>License curation applied on match</h6>
+      <b-row>
+        <b-col sm="6">
+          <b-form-group
+            label="License override"
+            label-for="policy-license"
+            description="Applied to matching components on every BOM import"
+          >
+            <b-form-select
+              id="policy-license"
+              v-model="policy.license"
+              :options="selectableLicenses"
+            />
+          </b-form-group>
+        </b-col>
+        <b-col sm="6">
+          <b-form-group label="Details" label-for="policy-details">
+            <b-form-textarea
+              id="policy-details"
+              v-model="policy.details"
+              rows="2"
+              placeholder="Written onto matched components (visible in their notes)"
+            />
+          </b-form-group>
+        </b-col>
+      </b-row>
+
+      <template #footer>
+        <div class="d-flex">
+          <b-button
+            v-if="policyId"
+            variant="outline-danger"
+            @click="deletePolicy"
+            >{{ $t('message.delete') }}</b-button
+          >
+          <div class="ml-auto">
+            <b-button variant="secondary" class="mr-2" @click="goBack">{{
+              $t('message.cancel')
+            }}</b-button>
+            <b-button variant="primary" @click="savePolicy">{{
+              policyId ? $t('message.update') : $t('message.create')
+            }}</b-button>
+          </div>
+        </div>
+      </template>
+    </b-card>
+  </div>
+</template>
+
+<script>
+import permissionsMixin from '../../mixins/permissionsMixin';
+import BInputGroupFormInput from '../../forms/BInputGroupFormInput';
+import BInputGroupFormDatepicker from '../../forms/BInputGroupFormDatepicker';
+import CodeMirrorEditor from '@/views/components/CodeMirrorEditor.vue';
+import { createCelCompletionSource } from './celCompletions';
+
+export default {
+  components: {
+    BInputGroupFormInput,
+    BInputGroupFormDatepicker,
+    CodeMirrorEditor,
+  },
+  mixins: [permissionsMixin],
+  props: {
+    policyId: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      celCompletionSource: createCelCompletionSource({
+        vuln: undefined,
+        vulns: undefined,
+      }),
+      selectableLicenses: [],
+      operationModeOptions: [
+        { value: 'APPLY', text: 'Apply' },
+        { value: 'DISABLED', text: 'Disabled' },
+      ],
+      policy: {
+        name: '',
+        description: '',
+        operationMode: 'APPLY',
+        priority: '0',
+        validFrom: null,
+        validUntil: null,
+        condition: '',
+        license: '',
+        details: '',
+      },
+      conditionTemplates: [
+        {
+          label: 'Component has no license at all',
+          value:
+            '!has(component.resolved_license) && component.license_name == "" && component.license_expression == ""',
+        },
+        {
+          label: 'Component license could not be resolved',
+          value: '!has(component.resolved_license)',
+        },
+        {
+          label: 'Component declares a multi-license expression',
+          value: 'component.license_expression != ""',
+        },
+        {
+          label: 'Component has a specific resolved license',
+          value: 'component.resolved_license.id == "GPL-3.0-only"',
+        },
+        {
+          label: 'Components of one ecosystem (purl prefix)',
+          value: 'component.purl.startsWith("pkg:pypi/")',
+        },
+        {
+          label: 'One specific component without license (exact purl)',
+          value:
+            'component.purl == "pkg:pypi/example@1.0.0" && !has(component.resolved_license) && component.license_name == "" && component.license_expression == ""',
+        },
+        {
+          label: 'One specific component (name and version)',
+          value: 'component.name == "example" && component.version == "1.0.0"',
+        },
+        {
+          label: 'Ecosystem within one project',
+          value:
+            'project.name == "my-repo" && component.purl.startsWith("pkg:npm/")',
+        },
+      ],
+    };
+  },
+  computed: {
+    pageTitle() {
+      return this.policyId
+        ? 'Edit Component Policy'
+        : 'Create Component Policy';
+    },
+    priorityLabel() {
+      const priority = Number(this.policy.priority);
+      if (priority <= 25) return this.$t('message.policy_priority_high');
+      if (priority <= 75) return this.$t('message.policy_priority_normal');
+      return this.$t('message.policy_priority_low');
+    },
+  },
+  created() {
+    this.retrieveLicenses();
+    if (this.policyId) {
+      this.loadPolicy();
+    }
+  },
+  methods: {
+    insertTemplate(tpl) {
+      const current = (this.policy.condition || '').trimEnd();
+      const combined = current ? `${current}\n&& ${tpl.value}` : tpl.value;
+      this.policy.condition = combined;
+      if (this.$refs.conditionEditor?.setValue) {
+        this.$refs.conditionEditor.setValue(combined);
+      }
+    },
+    retrieveLicenses() {
+      const url = `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_CONCISE}`;
+      this.axios.get(url).then((response) => {
+        const licenses = [{ value: '', text: '' }];
+        for (const license of response.data) {
+          licenses.push({
+            value: license.licenseId || license.name,
+            text: license.name,
+          });
+        }
+        this.selectableLicenses = licenses;
+      });
+    },
+    loadPolicy() {
+      const url = `${this.$api.BASE_URL}/api/v2/component-policies`;
+      this.axios.get(url).then((response) => {
+        const policy = (response.data.policies || []).find(
+          (candidate) => String(candidate.id) === String(this.policyId),
+        );
+        if (!policy) {
+          this.$toastr.w(this.$t('condition.unsuccessful_action'));
+          return;
+        }
+        this.policy = {
+          name: policy.name,
+          description: policy.description || '',
+          operationMode: policy.enabled ? 'APPLY' : 'DISABLED',
+          priority: String(policy.priority),
+          validFrom: policy.validFrom ? policy.validFrom.slice(0, 10) : null,
+          validUntil: policy.validUntil ? policy.validUntil.slice(0, 10) : null,
+          condition: policy.condition,
+          license: policy.license || '',
+          details: policy.details || '',
+        };
+        if (this.$refs.conditionEditor?.setValue) {
+          this.$refs.conditionEditor.setValue(policy.condition);
+        }
+      });
+    },
+    savePolicy() {
+      const body = {
+        name: this.policy.name,
+        description: this.policy.description || null,
+        enabled: this.policy.operationMode === 'APPLY',
+        priority: Number(this.policy.priority) || 0,
+        condition: this.policy.condition,
+        license: this.policy.license || null,
+        details: this.policy.details || null,
+        validFrom: this.policy.validFrom
+          ? `${this.policy.validFrom}T00:00:00Z`
+          : null,
+        validUntil: this.policy.validUntil
+          ? `${this.policy.validUntil}T23:59:59Z`
+          : null,
+      };
+      const base = `${this.$api.BASE_URL}/api/v2/component-policies`;
+      const request = this.policyId
+        ? this.axios.put(`${base}/${this.policyId}`, body)
+        : this.axios.post(base, body);
+      request
+        .then(() => {
+          this.$toastr.s(this.$t('message.updated'));
+          this.goBack();
+        })
+        .catch((error) => {
+          this.$toastr.w(
+            error.response && error.response.status === 400
+              ? 'Rejected: check the CEL condition and that the license exists'
+              : this.$t('condition.unsuccessful_action'),
+          );
+        });
+    },
+    deletePolicy() {
+      const url = `${this.$api.BASE_URL}/api/v2/component-policies/${this.policyId}`;
+      this.axios.delete(url).then(() => {
+        this.$toastr.s(this.$t('message.policy_deleted'));
+        this.goBack();
+      });
+    },
+    goBack() {
+      this.$router.push('/policy/componentPolicies');
+    },
+  },
+};
+</script>

--- a/src/views/policy/ComponentPolicyList.vue
+++ b/src/views/policy/ComponentPolicyList.vue
@@ -109,14 +109,14 @@ export default {
         },
         {
           title: this.$t('message.validFrom'),
-          field: 'validFrom',
+          field: 'valid_from',
           visible: initialColumnVisible('validFrom', false),
           formatter: (value) =>
             value ? common.formatTimestamp(Date.parse(value)) : '',
         },
         {
           title: this.$t('message.validUntil'),
-          field: 'validUntil',
+          field: 'valid_until',
           visible: initialColumnVisible('validUntil', false),
           formatter: (value) =>
             value ? common.formatTimestamp(Date.parse(value)) : '',

--- a/src/views/policy/ComponentPolicyList.vue
+++ b/src/views/policy/ComponentPolicyList.vue
@@ -1,0 +1,151 @@
+<template>
+  <div>
+    <div id="componentPoliciesToolbar" class="bs-bars pull-left">
+      <div class="form-inline" role="form">
+        <b-button
+          size="md"
+          variant="outline-primary"
+          :to="{ name: 'ComponentPolicyCreate' }"
+        >
+          <span class="fa fa-plus"></span> Create Policy
+        </b-button>
+      </div>
+    </div>
+    <bootstrap-table
+      ref="table"
+      :columns="columns"
+      :data="policies"
+      :options="tableOptions"
+    />
+  </div>
+</template>
+
+<script>
+import common from '../../shared/common';
+import xssFilters from 'xss-filters';
+import permissionsMixin from '@/mixins/permissionsMixin';
+
+const initialColumnVisible = (field, fallback) => {
+  const stored = localStorage
+    ? localStorage.getItem('ComponentPolicyListShow' + common.capitalize(field))
+    : null;
+  return stored !== null ? stored === 'true' : fallback;
+};
+
+export default {
+  mixins: [permissionsMixin],
+  data() {
+    return {
+      policies: [],
+      tableOptions: {
+        toolbar: '#componentPoliciesToolbar',
+        search: true,
+        searchTimeOut: 200,
+        showColumns: true,
+        showRefresh: true,
+        pagination: true,
+        sidePagination: 'client',
+        pageSize: 10,
+        pageList: '[10, 25, 50, 100]',
+        icons: {
+          refresh: 'fa-refresh',
+          columns: 'fa-th-list',
+        },
+        onRefresh: () => {
+          this.loadPolicies();
+        },
+        onColumnSwitch: (field, checked) => {
+          if (localStorage) {
+            localStorage.setItem(
+              'ComponentPolicyListShow' + common.capitalize(field),
+              checked.toString(),
+            );
+          }
+        },
+      },
+      columns: [
+        {
+          title: this.$t('message.name'),
+          field: 'name',
+          sortable: true,
+          formatter: (value, row) => {
+            const href = this.$router.resolve({
+              name: 'ComponentPolicyEdit',
+              params: { id: String(row.id) },
+            }).href;
+            return `<a href="${href}">${xssFilters.inHTMLData(common.valueWithDefault(value, ''))}</a>`;
+          },
+        },
+        {
+          title: this.$t('message.policy_operation_mode'),
+          field: 'enabled',
+          sortable: true,
+          visible: initialColumnVisible('enabled', true),
+          formatter: (value) =>
+            value
+              ? '<span class="badge badge-info">Apply</span>'
+              : '<span class="badge badge-secondary">Disabled</span>',
+        },
+        {
+          title: this.$t('message.policy_priority'),
+          field: 'priority',
+          sortable: true,
+          visible: initialColumnVisible('priority', true),
+        },
+        {
+          title: 'License override',
+          field: 'license',
+          sortable: true,
+          visible: initialColumnVisible('license', true),
+          formatter: (value) =>
+            xssFilters.inHTMLData(common.valueWithDefault(value, '')),
+        },
+        {
+          title: 'Details',
+          field: 'details',
+          visible: initialColumnVisible('details', false),
+          formatter: (value) =>
+            xssFilters.inHTMLData(common.valueWithDefault(value, '')),
+        },
+        {
+          title: this.$t('message.validFrom'),
+          field: 'validFrom',
+          visible: initialColumnVisible('validFrom', false),
+          formatter: (value) =>
+            value ? common.formatTimestamp(Date.parse(value)) : '',
+        },
+        {
+          title: this.$t('message.validUntil'),
+          field: 'validUntil',
+          visible: initialColumnVisible('validUntil', false),
+          formatter: (value) =>
+            value ? common.formatTimestamp(Date.parse(value)) : '',
+        },
+        {
+          title: this.$t('message.author'),
+          field: 'author',
+          sortable: true,
+          visible: initialColumnVisible('author', true),
+          formatter: (value) =>
+            xssFilters.inHTMLData(common.valueWithDefault(value, '')),
+        },
+      ],
+    };
+  },
+  created() {
+    this.loadPolicies();
+  },
+  methods: {
+    loadPolicies() {
+      const url = `${this.$api.BASE_URL}/api/v2/component-policies`;
+      this.axios.get(url).then((response) => {
+        this.policies = response.data.policies || [];
+        this.$emit('total', this.policies.length);
+        if (this.$refs.table) {
+          this.$refs.table.load(this.policies, { silent: true });
+        }
+      });
+    },
+  },
+};
+</script>

--- a/src/views/policy/PolicyManagement.vue
+++ b/src/views/policy/PolicyManagement.vue
@@ -36,6 +36,16 @@
         >
         <license-group-list v-on:total="totalLicenseGroups = $event" />
       </b-tab>
+      <b-tab ref="componentpolicies" @click="routeTo('componentPolicies')">
+        <template v-slot:title
+          ><i class="fa fa-balance-scale"></i>
+          {{ $t('message.component_policies') }}
+          <b-badge variant="tab-total">{{
+            totalComponentPolicies
+          }}</b-badge></template
+        >
+        <component-policy-list v-on:total="totalComponentPolicies = $event" />
+      </b-tab>
       <b-tab
         ref="vulnerability"
         class="body-bg-color overview-chart"
@@ -61,11 +71,13 @@
 import permissionsMixin from '../../mixins/permissionsMixin';
 import PolicyList from './PolicyList';
 import LicenseGroupList from './LicenseGroupList';
+import ComponentPolicyList from './ComponentPolicyList';
 import VulnerabilityPolicyList from './VulnerabilityPolicyList';
 
 export default {
   mixins: [permissionsMixin],
   components: {
+    ComponentPolicyList,
     LicenseGroupList,
     PolicyList,
     VulnerabilityPolicyList,
@@ -75,6 +87,7 @@ export default {
       totalPolicies: 0,
       totalLicenseGroups: 0,
       totalVulnerabilityPolicies: 0,
+      totalComponentPolicies: 0,
     };
   },
   methods: {

--- a/src/views/portfolio/projects/ComponentAudit.vue
+++ b/src/views/portfolio/projects/ComponentAudit.vue
@@ -193,7 +193,7 @@ export default {
         if (analysis) {
           this.analysisId = analysis.id;
           this.overrideLicense = analysis.license;
-          this.declaredLicense = analysis.declaredLicense;
+          this.declaredLicense = analysis.declared_license;
           this.details = analysis.details;
           this.loadComments();
         }
@@ -214,8 +214,8 @@ export default {
           if (comment.commenter) {
             trail += comment.commenter + ' - ';
           }
-          // v2 serializes timestamps as epoch seconds
-          trail += common.formatTimestamp(comment.timestamp * 1000, true);
+          // v2 serializes timestamps as epoch milliseconds
+          trail += common.formatTimestamp(comment.timestamp, true);
           trail += '\n' + comment.comment + '\n\n';
         }
         this.auditTrail = trail;
@@ -225,7 +225,7 @@ export default {
       const url = `${this.$api.BASE_URL}/api/v2/component-analyses`;
       this.axios
         .put(url, {
-          projectUuid: this.projectUuid,
+          project_uuid: this.projectUuid,
           purl: this.component.purl || null,
           group: this.component.group || null,
           name: this.component.name,
@@ -233,10 +233,9 @@ export default {
           license: this.overrideLicense || null,
           details: this.details || null,
         })
-        .then((response) => {
-          this.analysisId = response.data.id;
+        .then(() => {
           this.$toastr.s(this.$t('message.updated'));
-          this.loadComments();
+          this.loadAnalysis();
         })
         .catch((error) => {
           this.$toastr.w(

--- a/src/views/portfolio/projects/ComponentAudit.vue
+++ b/src/views/portfolio/projects/ComponentAudit.vue
@@ -1,0 +1,261 @@
+<template>
+  <b-row class="expanded-row">
+    <b-col sm="6">
+      <b-form-group label="Uploaded license" label-for="uploaded-license">
+        <b-form-input
+          id="uploaded-license"
+          :value="uploadedLicense"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group
+        v-if="component.description"
+        :label="this.$t('message.description')"
+        label-for="component-description"
+      >
+        <b-form-textarea
+          id="component-description"
+          :value="component.description"
+          rows="7"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group
+        v-if="component.purl"
+        label="Package URL"
+        label-for="component-purl"
+      >
+        <b-form-input
+          id="component-purl"
+          :value="component.purl"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+    </b-col>
+    <b-col sm="6">
+      <b-form-group label="Audit Trail" label-for="audit-trail">
+        <b-form-textarea
+          id="audit-trail"
+          v-model="auditTrail"
+          rows="7"
+          class="form-control disabled"
+          readonly
+          trim
+        />
+      </b-form-group>
+      <b-form-group label="Comment" label-for="audit-comment">
+        <b-form-textarea
+          id="audit-comment"
+          v-model="comment"
+          rows="3"
+          class="form-control"
+          :disabled="!analysisId || !canEdit"
+          trim
+        />
+        <div class="pull-right">
+          <b-button
+            size="sm"
+            variant="outline-primary"
+            :disabled="!analysisId || !comment || !canEdit"
+            @click="addComment"
+            ><span class="fa fa-comment-o"></span>
+            {{ this.$t('message.add_comment') }}</b-button
+          >
+        </div>
+      </b-form-group>
+      <b-form-group label="License override" label-for="override-license">
+        <b-form-select
+          id="override-license"
+          v-model="overrideLicense"
+          :options="selectableLicenses"
+          :disabled="!canEdit"
+        />
+      </b-form-group>
+      <b-form-group label="Details" label-for="override-details">
+        <b-form-textarea
+          id="override-details"
+          v-model="details"
+          rows="3"
+          class="form-control"
+          :disabled="!canEdit"
+          placeholder="Why this license override is correct (visible on the component)"
+          trim
+        />
+        <div class="pull-right">
+          <b-button
+            size="sm"
+            variant="outline-primary"
+            :disabled="!canEdit"
+            @click="upsertAnalysis"
+            ><span class="fa fa-comment-o"></span>
+            {{ this.$t('message.update_details') }}</b-button
+          >
+        </div>
+      </b-form-group>
+    </b-col>
+  </b-row>
+</template>
+
+<script>
+import common from '@/shared/common';
+import permissionsMixin from '@/mixins/permissionsMixin';
+
+export default {
+  props: {
+    component: Object,
+    projectUuid: String,
+  },
+  mixins: [permissionsMixin],
+  data() {
+    return {
+      selectableLicenses: [],
+      initialized: false,
+      analysisId: null,
+      declaredLicense: null,
+      auditTrail: null,
+      comment: null,
+      overrideLicense: null,
+      details: null,
+    };
+  },
+  computed: {
+    canEdit: function () {
+      return this.isPermitted(this.PERMISSIONS.POLICY_MANAGEMENT);
+    },
+    uploadedLicense: function () {
+      // with an override stored, the snapshot holds the uploaded value;
+      // without one, the component itself still carries it
+      if (this.declaredLicense) {
+        return this.declaredLicense;
+      }
+      if (this.analysisId && this.overrideLicense) {
+        return '(none)';
+      }
+      if (this.component.resolvedLicense) {
+        return (
+          this.component.resolvedLicense.licenseId ||
+          this.component.resolvedLicense.name
+        );
+      }
+      return (
+        this.component.license || this.component.licenseExpression || '(none)'
+      );
+    },
+  },
+  created() {
+    this.retrieveLicenses();
+    this.loadAnalysis();
+  },
+  watch: {
+    overrideLicense: function () {
+      if (this.initialized) {
+        this.upsertAnalysis();
+      }
+    },
+  },
+  methods: {
+    retrieveLicenses: function () {
+      const url = `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_CONCISE}`;
+      this.axios.get(url).then((response) => {
+        // Empty option = no override; custom licenses have no licenseId,
+        // their name doubles as the identifier.
+        const licenses = [{ value: '', text: '' }];
+        for (const license of response.data) {
+          licenses.push({
+            value: license.licenseId || license.name,
+            text: license.name,
+          });
+        }
+        this.selectableLicenses = licenses;
+      });
+    },
+    identityMatches: function (analysis) {
+      const norm = (value) => value || '';
+      return (
+        norm(analysis.purl) === norm(this.component.purl) &&
+        norm(analysis.group) === norm(this.component.group) &&
+        norm(analysis.name) === norm(this.component.name) &&
+        norm(analysis.version) === norm(this.component.version)
+      );
+    },
+    loadAnalysis: function () {
+      const url = `${this.$api.BASE_URL}/api/v2/component-analyses?project=${this.projectUuid}`;
+      this.axios.get(url).then((response) => {
+        const analysis = (response.data.analyses || []).find(
+          this.identityMatches,
+        );
+        if (analysis) {
+          this.analysisId = analysis.id;
+          this.overrideLicense = analysis.license;
+          this.declaredLicense = analysis.declaredLicense;
+          this.details = analysis.details;
+          this.loadComments();
+        }
+        // saves triggered by user edits only, not by this initial load
+        this.$nextTick(() => {
+          this.initialized = true;
+        });
+      });
+    },
+    loadComments: function () {
+      if (!this.analysisId) {
+        return;
+      }
+      const url = `${this.$api.BASE_URL}/api/v2/component-analyses/${this.analysisId}/comments`;
+      this.axios.get(url).then((response) => {
+        let trail = '';
+        for (const comment of response.data.comments || []) {
+          if (comment.commenter) {
+            trail += comment.commenter + ' - ';
+          }
+          // v2 serializes timestamps as epoch seconds
+          trail += common.formatTimestamp(comment.timestamp * 1000, true);
+          trail += '\n' + comment.comment + '\n\n';
+        }
+        this.auditTrail = trail;
+      });
+    },
+    upsertAnalysis: function () {
+      const url = `${this.$api.BASE_URL}/api/v2/component-analyses`;
+      this.axios
+        .put(url, {
+          projectUuid: this.projectUuid,
+          purl: this.component.purl || null,
+          group: this.component.group || null,
+          name: this.component.name,
+          version: this.component.version || null,
+          license: this.overrideLicense || null,
+          details: this.details || null,
+        })
+        .then((response) => {
+          this.analysisId = response.data.id;
+          this.$toastr.s(this.$t('message.updated'));
+          this.loadComments();
+        })
+        .catch((error) => {
+          this.$toastr.w(
+            error.response && error.response.status === 400
+              ? 'Unknown license — create it as a custom license first'
+              : this.$t('condition.unsuccessful_action'),
+          );
+        });
+    },
+    addComment: function () {
+      if (!this.analysisId || !this.comment) {
+        return;
+      }
+      const url = `${this.$api.BASE_URL}/api/v2/component-analyses/${this.analysisId}/comments`;
+      this.axios.post(url, { comment: this.comment }).then(() => {
+        this.comment = null;
+        this.loadComments();
+      });
+    },
+  },
+};
+</script>

--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -463,16 +463,6 @@
     <template v-slot:modal-footer="{ cancel }">
       <b-button
         size="md"
-        variant="outline-danger"
-        @click="deleteComponent()"
-        v-permission:or="[
-          PERMISSIONS.PORTFOLIO_MANAGEMENT,
-          PERMISSIONS.PORTFOLIO_MANAGEMENT_DELETE,
-        ]"
-        >{{ $t('message.delete') }}</b-button
-      >
-      <b-button
-        size="md"
         variant="outline-primary"
         v-b-modal.componentPropertiesModal
         v-permission:or="[
@@ -484,16 +474,6 @@
       <b-button size="md" variant="secondary" @click="cancel()">{{
         $t('message.close')
       }}</b-button>
-      <b-button
-        size="md"
-        variant="primary"
-        @click="updateComponent()"
-        v-permission:or="[
-          PERMISSIONS.PORTFOLIO_MANAGEMENT,
-          PERMISSIONS.PORTFOLIO_MANAGEMENT_UPDATE,
-        ]"
-        >{{ $t('message.update') }}</b-button
-      >
     </template>
   </b-modal>
 </template>
@@ -652,6 +632,13 @@ export default {
     //console.log(this.component);
   },
   methods: {
+    // Components are managed by SBOM uploads; license curation happens via
+    // component analyses and component policies. The details view is
+    // therefore read-only for everyone, regardless of permissions.
+    isNotPermitted() {
+      return true;
+    },
+
     updateComponent: function () {
       this.$root.$emit('bv::hide::modal', 'componentDetailsModal');
       let url = `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}`;

--- a/src/views/portfolio/projects/ComponentDetailsModal.vue
+++ b/src/views/portfolio/projects/ComponentDetailsModal.vue
@@ -462,6 +462,17 @@
     </b-tabs>
     <template v-slot:modal-footer="{ cancel }">
       <b-button
+        v-if="component && component.manuallyCreated"
+        size="md"
+        variant="outline-danger"
+        @click="deleteComponent()"
+        v-permission:or="[
+          PERMISSIONS.PORTFOLIO_MANAGEMENT,
+          PERMISSIONS.PORTFOLIO_MANAGEMENT_DELETE,
+        ]"
+        >{{ $t('message.delete') }}</b-button
+      >
+      <b-button
         size="md"
         variant="outline-primary"
         v-b-modal.componentPropertiesModal
@@ -474,6 +485,17 @@
       <b-button size="md" variant="secondary" @click="cancel()">{{
         $t('message.close')
       }}</b-button>
+      <b-button
+        v-if="component && component.manuallyCreated"
+        size="md"
+        variant="primary"
+        @click="updateComponent()"
+        v-permission:or="[
+          PERMISSIONS.PORTFOLIO_MANAGEMENT,
+          PERMISSIONS.PORTFOLIO_MANAGEMENT_UPDATE,
+        ]"
+        >{{ $t('message.update') }}</b-button
+      >
     </template>
   </b-modal>
 </template>
@@ -632,11 +654,15 @@ export default {
     //console.log(this.component);
   },
   methods: {
-    // Components are managed by SBOM uploads; license curation happens via
-    // component analyses and component policies. The details view is
-    // therefore read-only for everyone, regardless of permissions.
-    isNotPermitted() {
-      return true;
+    // Imported components are managed by SBOM uploads and curated via
+    // component analyses and component policies, so their details are
+    // read-only. Only manually created components are editable, subject to
+    // the caller's regular permissions.
+    isNotPermitted(permissions) {
+      return (
+        !(this.component && this.component.manuallyCreated) ||
+        !this.isPermitted(permissions)
+      );
     },
 
     updateComponent: function () {

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -131,6 +131,7 @@
 <script>
 import { compareVersions } from '@/shared/utils';
 import ComponentOccurrenceListModal from '@/views/portfolio/projects/ComponentOccurrenceListModal.vue';
+import ComponentAudit from '@/views/portfolio/projects/ComponentAudit.vue';
 import ProjectAddComponentModal from '@/views/portfolio/projects/ProjectAddComponentModal';
 import ProjectUploadBomModal from '@/views/portfolio/projects/ProjectUploadBomModal';
 import TokenPaginatedTable from '@/views/components/TokenPaginatedTable.vue';
@@ -221,8 +222,34 @@ export default {
       searchText: null,
       visibleColumns: initialVisibleColumns,
       columns: this.buildColumns(),
+      analysisByIdentity: {},
       tableOptions: {
         toolbar: '#componentsToolbar',
+        onRefresh: () => {
+          this.fetchComponentAnalyses();
+        },
+        icons: {
+          detailOpen: 'fa-fw fa-angle-right',
+          detailClose: 'fa-fw fa-angle-down',
+          refresh: 'fa-refresh',
+        },
+        detailView: true,
+        detailViewIcon: true,
+        detailViewByClick: false,
+        detailFormatter: (index, row) => {
+          return (
+            row &&
+            this.vueFormatter({
+              i18n,
+              propsData: {
+                component: row,
+                projectUuid: this.uuid,
+              },
+              ...ComponentAudit,
+            })
+          );
+        },
+        onExpandRow: this.vueFormatterInit,
         search: true,
         searchable: false,
         onSearch: (text) => {
@@ -275,6 +302,9 @@ export default {
       }
       return { expand: [...expand] };
     },
+  },
+  created() {
+    this.fetchComponentAnalyses();
   },
   methods: {
     buildBaseParams() {
@@ -443,6 +473,23 @@ export default {
               );
             }
             return '';
+          },
+        },
+        {
+          title: 'Override',
+          field: 'override',
+          sortable: false,
+          visible: initialColumnVisible('override'),
+          formatter: (value, row) => {
+            const analysis = this.analysisByIdentity[this.identityKey(row)];
+            if (!analysis || !analysis.license) {
+              return '';
+            }
+            return (
+              '<i class="fa fa-balance-scale" data-toggle="tooltip" title="' +
+              xssFilters.inHTMLData('License override: ' + analysis.license) +
+              '"></i>'
+            );
           },
         },
         {
@@ -644,9 +691,36 @@ export default {
       return { items, partial: true };
     },
     refreshTable() {
+      this.fetchComponentAnalyses();
       if (this.$refs.table) {
         this.$refs.table.refreshCurrentPage();
       }
+    },
+    identityKey(row) {
+      const norm = (value) => value || '';
+      return [
+        norm(row.purl),
+        norm(row.group),
+        norm(row.name),
+        norm(row.version),
+      ].join('|');
+    },
+    fetchComponentAnalyses() {
+      const url = `${this.$api.BASE_URL}/api/v2/component-analyses?project=${this.uuid}`;
+      this.axios.get(url).then((response) => {
+        const map = {};
+        for (const analysis of response.data.analyses || []) {
+          map[this.identityKey(analysis)] = analysis;
+        }
+        // re-render only when the flags actually changed — onRefresh calls
+        // this too, and an unconditional re-render would loop
+        const changed =
+          JSON.stringify(map) !== JSON.stringify(this.analysisByIdentity);
+        this.analysisByIdentity = map;
+        if (changed && this.$refs.table) {
+          this.$refs.table.refreshCurrentPage();
+        }
+      });
     },
   },
 };


### PR DESCRIPTION
### Description

UI for durable component license curation, the frontend counterpart of DependencyTrack/dependency-track#6961:

- **Component audit panel** on the project components table: expanding a component shows its license curation state — the BOM-declared license, the active override, free-text details, and the full audit trail of comments; users with the required permission can set or clear the override and add comments from there.
- **Component Policies tab** under Policy Management: create, edit, prioritize, and delete component policies — a CEL condition editor with autocomplete and ready-made condition templates (e.g. "component has no license at all", "one specific component by purl"), a license override selector, a 0–100 priority slider with Highest/High/Normal/Low labels, and validity dates.
- **Component editing restricted to manually created components**: edit and delete controls on BOM-imported components are disabled, matching the API's 405 responses; manually created components stay fully editable.

All new UI strings go through i18n (`message.component_policies` added to every locale file; other labels reuse existing keys).

### Addressed Issue

Frontend part of DependencyTrack/dependency-track#251 (see DependencyTrack/dependency-track#6961 for the API server part — the design is recorded in ADR 036 included there).

### Additional Details

- The audit panel and the policy editor speak the spec-first v2 endpoints introduced by the API server PR: `/component-analyses` (+ comments) and `/component-policies`.
- The priority label bands map the numeric priority to upstream's existing vocabulary (`policy_priority_highest/high/normal/low`) rather than introducing new terms.
- Verified locally: eslint clean on the new components, prettier clean repo-wide, `vue-i18n-extract report --ci` reports zero missing keys, and the production build succeeds.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
