### PR TITLE
Remount the project properties modal when the project UUID changes

### DIFF
--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -424,7 +424,7 @@
       :uuid="this.uuid"
       v-on:projectUpdated="syncProjectFields"
     />
-    <project-properties-modal :uuid="this.uuid" />
+    <project-properties-modal :key="this.uuid" :uuid="this.uuid" />
     <project-create-property-modal :uuid="this.uuid" />
     <project-add-version-modal :uuid="this.uuid" />
   </div>


### PR DESCRIPTION
### Description
Remount the project properties modal when the project UUID changes, so properties always reflect the selected project version instead of previously loaded values.

### Addressed Issue
Fixes #1495 

### Additional Details

### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
