### PR TITLE
Automatically trigger OIDC login if redirected

### DIFF
--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -290,6 +290,11 @@ export default {
         this.oidcUserManager.getUser().then((oidcUser) => {
           // oidcUser will only be set when coming from oidc-callback.html
           if (oidcUser === null) {
+            // Automatically trigger OIDC login if we got redirected.
+            // Don't do it otherwise so users can navigate manually to /login.
+            if (this.$router.currentRoute.query.redirect) {
+              this.oidcLogin();
+            }
             return;
           }
 


### PR DESCRIPTION
### Description

Automatically trigger OIDC login if we got redirected. The redirect originates here:

https://github.com/DependencyTrack/frontend/blob/82b6350a4d4d0cdc8f8c5190a884ee5655dcc28d/src/router/index.js#L1210-L1212

### Addressed Issue

Fixes #530.

### Additional Details

I have considered introducing a config option / feature flag for this, but decided against it.
I'd expect all users to want this behavior.

I have tested this locally, both that the auto-redirect works and that manually navigating to `/login` does not trigger it.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and ~~I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~~ IMHO insufficiently significant of a change for the docs, but should be in release notes.
