### PR TITLE
Show assigned teams in project details.

### DIFF
--- a/src/views/portfolio/projects/ProjectDetailsModal.vue
+++ b/src/views/portfolio/projects/ProjectDetailsModal.vue
@@ -168,6 +168,21 @@
                 "
               />
             </b-form-group>
+            <b-form-group
+              v-if="accessTeams.length"
+              id="project-teams-form-group"
+              :label="$t('message.team')"
+            >
+              <div class="form-control h-auto">
+                <span
+                  v-for="team in accessTeams"
+                  :key="team.uuid || team.name"
+                  class="badge badge-team text-lowercase mr-1"
+                >
+                  {{ team.name }}
+                </span>
+              </div>
+            </b-form-group>
             <div style="margin-bottom: 1rem">
               <label>{{ $t('message.parent') }}</label>
               <multiselect
@@ -910,6 +925,11 @@ export default {
     },
   },
   computed: {
+    accessTeams() {
+      return [...(this.project.accessTeams || [])].sort((a, b) =>
+        (a.name || '').localeCompare(b.name || ''),
+      );
+    },
     inactiveSinceTimestamp: function () {
       return this.project.inactiveSince
         ? this.$t('message.inactive_since') +


### PR DESCRIPTION
### Description
Show assigned teams in the project details modal.

Teams assigned to a project were not visible in the UI. The details view now lists assigned access teams as badges, sorted by name. The section is hidden when no teams are assigned.
<img width="1222" height="839" alt="Screenshot 2026-08-17 163704" src="https://github.com/user-attachments/assets/ca12fd25-90f9-44c8-a4aa-35772cc7fcce" />


### Addressed Issue
#1752 

### Additional Details
Requires the corresponding API change that includes accessTeams in project responses.
Backend PR: [https://github.com/DependencyTrack/dependency-track/pull/7013](https://github.com/DependencyTrack/dependency-track/pull/7013)

### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
