### PR TITLE
Support extension display names and root-level config descriptions

### DIFF
--- a/src/views/administration/AdminMenu.vue
+++ b/src/views/administration/AdminMenu.vue
@@ -111,7 +111,7 @@ export default {
             const route = routePrefix + '/' + encodedName;
             return {
               id: route,
-              name: common.titleCase(ext.name),
+              name: ext.display_name || common.titleCase(ext.name),
               route: route,
               configurable: ext.configurable !== false,
             };

--- a/src/views/administration/analyzers/Index.vue
+++ b/src/views/administration/analyzers/Index.vue
@@ -4,6 +4,9 @@
     :extension-name="$route.params.extensionName"
     extension-point-name="vuln-analyzer"
     :testable="selectedExtension ? selectedExtension.testable !== false : true"
+    :display-name="
+      selectedExtension ? selectedExtension.display_name : undefined
+    "
   />
 </template>
 

--- a/src/views/administration/data-sources/Index.vue
+++ b/src/views/administration/data-sources/Index.vue
@@ -4,6 +4,9 @@
     :extension-name="$route.params.extensionName"
     :extension-point-name="extensionPointName"
     :testable="selectedExtension ? selectedExtension.testable !== false : true"
+    :display-name="
+      selectedExtension ? selectedExtension.display_name : undefined
+    "
   >
     <template #footer-actions="{ operationInProgress, hasUnsavedChanges }">
       <data-source-mirror-button

--- a/src/views/components/ExtensionConfigForm.vue
+++ b/src/views/components/ExtensionConfigForm.vue
@@ -12,6 +12,12 @@
           {{ loadError }}
         </b-alert>
 
+        <showdown
+          v-if="!loadError && schema && schema.description"
+          :markdown="schema.description"
+          class="extension-config-form__description"
+        />
+
         <div v-if="!loadError && schema">
           <div
             v-for="(propSchema, propName) in schema.properties"
@@ -124,6 +130,7 @@ import Ajv from 'ajv/dist/2020';
 import addFormats from 'ajv-formats';
 import common from '../../shared/common';
 import JsonSchemaFormField from './JsonSchemaFormField.vue';
+import Showdown from './Showdown.vue';
 import {
   enrichSchema,
   getDefaultValue,
@@ -135,6 +142,7 @@ const CHECK_STATUS_ORDER = { FAILED: 0, SKIPPED: 1, PASSED: 2 };
 export default {
   components: {
     JsonSchemaFormField,
+    Showdown,
   },
   props: {
     extensionPointName: {
@@ -169,6 +177,11 @@ export default {
       required: false,
       default: undefined,
     },
+    displayName: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -190,7 +203,11 @@ export default {
       if (this.header !== undefined) {
         return this.header;
       }
-      return this.schema?.title || common.titleCase(this.extensionName);
+      return (
+        this.displayName ||
+        this.schema?.title ||
+        common.titleCase(this.extensionName)
+      );
     },
     normalizedFormData() {
       return this.normalizeFormData(this.formData);
@@ -577,6 +594,12 @@ export default {
 </script>
 
 <style scoped>
+.extension-config-form__description {
+  margin-bottom: 1rem;
+}
+.extension-config-form__description >>> p:last-child {
+  margin-bottom: 0;
+}
 .extension-config-form__skeleton {
   padding: 0.5rem 0;
 }

--- a/src/views/components/KevAssertionsModal.vue
+++ b/src/views/components/KevAssertionsModal.vue
@@ -21,7 +21,10 @@
     >
       <b-card-header class="d-flex align-items-center">
         <i class="fa fa-fire text-danger mr-2" aria-hidden="true"></i>
-        <strong>{{ (assertion.asserter || '').toUpperCase() }}</strong>
+        <strong>{{
+          assertion.asserter_display_name ||
+          (assertion.asserter || '').toUpperCase()
+        }}</strong>
         <b-badge
           v-if="assertion.known_ransomware === true"
           variant="danger"


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports extension display names and root-level config descriptions.

Prefers the dedicated display name of extensions over a title-cased name (which uses slug-style, e.g. `oss-index`).

If an extension config has a root-level `description` field, renders it at the top of the generated extension form. The main purpose here is to show a high-level description of extensions, and possibly fulfill attribution requirements dictated by license terms of an integration.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/issues/2267

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

API server PR: https://github.com/DependencyTrack/dependency-track/pull/7025

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly~
