### PR TITLE
fix(ui): show keyboard focus on sidebar toggler

### DIFF
--- a/src/assets/scss/_custom.scss
+++ b/src/assets/scss/_custom.scss
@@ -354,6 +354,10 @@ h6 {
 button:focus {
   outline: 0;
 }
+.navbar-toggler:focus-visible {
+  outline: 2px solid $primary;
+  outline-offset: -2px;
+}
 .badge-tab-total {
   border: 1px solid #60768c !important;
   background-color: $grey-900 !important;


### PR DESCRIPTION
### Description

Adds a visible focus indicator to the sidebar hamburger toggler when it receives keyboard focus.

The application globally removes button outlines, making the toggler’s focus state invisible while navigating with the Tab key. This change uses `:focus-visible` so keyboard users receive a clear indicator without changing mouse-click styling.

### Addressed Issue

Fixes #1202

### Testing

* Verified the change targets the `.navbar-toggler` elements rendered by `SidebarToggler`
* Confirmed the existing global button focus rule is overridden
* `git diff --check` passes
