### PR TITLE
Enable multi OSV data source config on UI

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Beim Warteschlangenvorgang für die interne Komponentenidentifikation ist ein Fehler aufgetreten. Weitere Informationen finden Sie in den Serverprotokollen.",
     "internal_identification_queued": "Interne Komponentenidentifikation in der Warteschlange",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "An error occurred queueing internal component identification. Check server logs for details",
     "internal_identification_queued": "Internal component identification queued",
     "json_schema_form": {
+      "item_number": "{item} {n}",
       "max_items": "Maximum {n} item. | Maximum {n} items.",
       "min_items": "Minimum {n} item. | Minimum {n} items.",
+      "no_items_configured": "No {item} configured",
       "remove_item_aria": "Remove item {n}",
       "remove_named_item_aria": "Remove {name}",
       "test_summary": "{passed} passed, {failed} failed, {skipped} skipped"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Se produjo un error al poner en cola la identificación de componentes internos. Consulte los registros del servidor para obtener más detalles",
     "internal_identification_queued": "Identificación de componentes internos en cola",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Une erreur s'est produite lors de la mise en file d'attente de l'identification des composants internes. Vérifiez les journaux du serveur pour plus de détails",
     "internal_identification_queued": "Identification des composants internes en file d'attente",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "आंतरिक घटक पहचान को कतारबद्ध करते समय त्रुटि हुई। विवरण के लिए सर्वर लॉग देखें",
     "internal_identification_queued": "आंतरिक घटक पहचान पंक्तिबद्ध",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Si è verificato un errore nell'accodamento dell'identificazione del componente interno. Controlla i log del server per i dettagli",
     "internal_identification_queued": "Identificazione del componente interno in coda",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "内部コンポーネント識別のキューイング中にエラーが発生しました。詳細についてはサーバーログを確認してください。",
     "internal_identification_queued": "内部コンポーネント識別がキューに登録されました",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "내부 컴포넌트 식별 작업을 큐에 등록하는 중 오류가 발생했습니다. 자세한 내용은 서버 로그를 확인하세요",
     "internal_identification_queued": "내부 컴포넌트 식별 작업이 큐에 등록되었습니다",
     "json_schema_form": {
+      "item_number": "{항목} {n}",
       "max_items": "최대 {n}개 항목. | 최대 {n}개 항목.",
       "min_items": "최소 {n}개 항목. | 최소 {n}개 항목.",
+      "no_items_configured": "설정된 {item}이(가) 없습니다.",
       "remove_item_aria": "항목 {n} 제거",
       "remove_named_item_aria": "{name} 제거",
       "test_summary": "성공 {passed}건, 실패 {failed}건, 건너뜀 {skipped}건"

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Wystąpił błąd podczas kolejkowania identyfikacji komponentów wewnętrznych. Sprawdź dzienniki serwera, aby uzyskać szczegółowe informacje",
     "internal_identification_queued": "Wewnętrzna identyfikacja komponentów w kolejce",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Ocorreu um erro ao enfileirar a identificação do componente interno. Verifique os logs do servidor para obter detalhes",
     "internal_identification_queued": "Identificação de componente interno na fila",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Ocorreu um erro ao enfileirar a identificação do componente interno. Verifique os logs do servidor para obter detalhes",
     "internal_identification_queued": "Identificação de componente interno na fila",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Произошла ошибка при постановке задачи по идентификации внутренних компонентов в очередь. Проверьте логи сервера для получения деталей.",
     "internal_identification_queued": "Идентификация внутренних компонентов поставлена в очередь",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "Сталася помилка при постановці в чергу ідентифікації внутрішнього компонента. Перевірте журнали сервера для отримання деталей",
     "internal_identification_queued": "Ідентифікацію внутрішнього компонента поставлено в чергу",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "排入內部元件識別佇列時發生錯誤。請檢視伺服器日誌了解詳細資訊",
     "internal_identification_queued": "內部元件識別已排入佇列",
     "json_schema_form": {
+      "item_number": "{項目} {n}",
       "max_items": "最多 {n} 項。 |最多 {n} 個項目。",
       "min_items": "最少 {n} 項。 |最少 {n} 項。",
+      "no_items_configured": "未配置 {item}",
       "remove_item_aria": "刪除項目 {n}",
       "remove_named_item_aria": "刪除{名稱}",
       "test_summary": "{passed} 通過，{failed} 失敗，{skipped} 跳過"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -159,8 +159,10 @@
     "internal_identification_error": "内部组件识别入队时发生错误。请查看服务器日志了解详细信息",
     "internal_identification_queued": "内部组件识别已加入队列",
     "json_schema_form": {
+      "item_number": null,
       "max_items": null,
       "min_items": null,
+      "no_items_configured": null,
       "remove_item_aria": null,
       "remove_named_item_aria": null,
       "test_summary": null

--- a/src/views/administration/data-sources/Index.vue
+++ b/src/views/administration/data-sources/Index.vue
@@ -93,7 +93,7 @@ export default {
             { property: 'name' },
           );
         } else if (names.filter((candidate) => candidate === name).length > 1) {
-          errors[`sources.${index}.name`] = this.$t('validation.schema.required');
+          errors[`sources.${index}.name`] = this.$t('validation.schema.unique_items');
         }
 
         if (sources.index?.enabled) {

--- a/src/views/administration/data-sources/Index.vue
+++ b/src/views/administration/data-sources/Index.vue
@@ -83,7 +83,7 @@ export default {
       const errors = {};
       const sources = Array.isArray(config?.sources) ? config.sources : [];
       const names = sources.map((source) =>
-        typeof source?.name === string ? source.name.trim() : '',
+        typeof source?.name === 'string' ? source.name.trim() : '',
       );
 
       names.forEach((name, index) => {
@@ -98,11 +98,9 @@ export default {
           );
         }
 
-        if (sources.index?.enabled) {
-          if (
-            Array.isArray(sources[index].ecosystems) ||
-            sources[index].ecosystems.length === 0
-          ) {
+        if (sources[index]?.enabled) {
+          const ecosystems = sources[index]?.ecosystems;
+          if (!Array.isArray(ecosystems) || ecosystems.length === 0) {
             errors[`sources.${index}.ecosystems`] = this.$t(
               'validation.schema.min_items',
               { limit: 1 },

--- a/src/views/administration/data-sources/Index.vue
+++ b/src/views/administration/data-sources/Index.vue
@@ -83,7 +83,7 @@ export default {
       const errors = {};
       const sources = Array.isArray(config?.sources) ? config.sources : [];
       const names = sources.map((source) =>
-        typeof source?.name === string ? source.name.trim() : ''
+        typeof source?.name === string ? source.name.trim() : '',
       );
 
       names.forEach((name, index) => {
@@ -93,11 +93,16 @@ export default {
             { property: 'name' },
           );
         } else if (names.filter((candidate) => candidate === name).length > 1) {
-          errors[`sources.${index}.name`] = this.$t('validation.schema.unique_items');
+          errors[`sources.${index}.name`] = this.$t(
+            'validation.schema.unique_items',
+          );
         }
 
         if (sources.index?.enabled) {
-          if (Array.isArray(sources[index].ecosystems) || sources[index].ecosystems.length === 0) {
+          if (
+            Array.isArray(sources[index].ecosystems) ||
+            sources[index].ecosystems.length === 0
+          ) {
             errors[`sources.${index}.ecosystems`] = this.$t(
               'validation.schema.min_items',
               { limit: 1 },
@@ -106,7 +111,7 @@ export default {
         }
       });
       return errors;
-    }
+    },
   },
 };
 </script>

--- a/src/views/administration/data-sources/Index.vue
+++ b/src/views/administration/data-sources/Index.vue
@@ -4,6 +4,8 @@
     :extension-name="$route.params.extensionName"
     :extension-point-name="extensionPointName"
     :testable="selectedExtension ? selectedExtension.testable !== false : true"
+    :tabbed-array-properties="tabbedArrayProperties"
+    :extra-validators="extraValidators"
     :display-name="
       selectedExtension ? selectedExtension.display_name : undefined
     "
@@ -38,6 +40,15 @@ export default {
     };
   },
   computed: {
+    tabbedArrayProperties() {
+      return this.$route.params.extensionName == 'osv' ? ['sources'] : [];
+    },
+    extraValidators() {
+      if (this.$route.params.extensionName !== 'osv') {
+        return [];
+      }
+      return [(config) => this.validateOsvSources(config)];
+    },
     selectedExtension() {
       const name = this.$route.params.extensionName;
       if (!name) return null;
@@ -68,6 +79,34 @@ export default {
         );
       }
     },
+    validateOsvSources(config) {
+      const errors = {};
+      const sources = Array.isArray(config?.sources) ? config.sources : [];
+      const names = sources.map((source) =>
+        typeof source?.name === string ? source.name.trim() : ''
+      );
+
+      names.forEach((name, index) => {
+        if (!name) {
+          errors[`sources.${index}.name`] = this.$t(
+            'validation.schema.required',
+            { property: 'name' },
+          );
+        } else if (names.filter((candidate) => candidate === name).length > 1) {
+          errors[`sources.${index}.name`] = this.$t('validation.schema.required');
+        }
+
+        if (sources.index?.enabled) {
+          if (Array.isArray(sources[index].ecosystems) || sources[index].ecosystems.length === 0) {
+            errors[`sources.${index}.ecosystems`] = this.$t(
+              'validation.schema.min_items',
+              { limit: 1 },
+            );
+          }
+        }
+      });
+      return errors;
+    }
   },
 };
 </script>

--- a/src/views/components/ExtensionConfigForm.vue
+++ b/src/views/components/ExtensionConfigForm.vue
@@ -30,6 +30,7 @@
               :value="formData[propName]"
               :validation-error="getValidationError(propName)"
               :validation-errors="nestedErrorMap[propName] || {}"
+              :tabbed="tabbedArrayProperties.includes(propName)"
               @input="onFieldChange(propName, $event)"
             />
           </div>
@@ -181,6 +182,14 @@ export default {
       type: String,
       required: false,
       default: undefined,
+    },
+    tabbedArrayProperties: {
+      type: Array,
+      default: () => [],
+    },
+    extraValidators: {
+      type: Array,
+      default: () => [],
     },
   },
   data() {
@@ -365,9 +374,9 @@ export default {
       }
       const validate = this.compiledValidator;
       const valid = validate(this.normalizedFormData);
+      const nextErrors = {};
 
       if (!valid) {
-        const nextErrors = {};
         validate.errors?.forEach((error) => {
           const field = error.instancePath
             .replace(/^\//, '')
@@ -383,12 +392,14 @@ export default {
             nextErrors[field] = message;
           }
         });
-        this.validationErrors = nextErrors;
-        return false;
       }
 
-      this.validationErrors = {};
-      return true;
+      this.extraValidators.forEach((validator) => {
+        Object.assign(nextErrors, validator(this.normalizedFormData) || {});
+      });
+
+      this.validationErrors = nextErrors;
+      return Object.keys(nextErrors).length === 0;
     },
     // Normalize form data by omitting fields that are null entirely.
     // Required for schema validation to correctly determine missing required fields.

--- a/src/views/components/JsonSchemaFormField.vue
+++ b/src/views/components/JsonSchemaFormField.vue
@@ -64,7 +64,8 @@ import SecretRefSelect from './SecretRefSelect.vue';
 
 const JsonSchemaObjectField = () => import('./JsonSchemaObjectField.vue');
 const JsonSchemaArrayField = () => import('./JsonSchemaArrayField.vue');
-const JsonSchemaTabbedArrayField = () => import('./JsonSchemaTabbedArrayField.vue');
+const JsonSchemaTabbedArrayField = () =>
+  import('./JsonSchemaTabbedArrayField.vue');
 
 export default {
   name: 'JsonSchemaFormField',

--- a/src/views/components/JsonSchemaFormField.vue
+++ b/src/views/components/JsonSchemaFormField.vue
@@ -64,6 +64,7 @@ import SecretRefSelect from './SecretRefSelect.vue';
 
 const JsonSchemaObjectField = () => import('./JsonSchemaObjectField.vue');
 const JsonSchemaArrayField = () => import('./JsonSchemaArrayField.vue');
+const JsonSchemaTabbedArrayField = () => import('./JsonSchemaTabbedArrayField.vue');
 
 export default {
   name: 'JsonSchemaFormField',
@@ -93,6 +94,10 @@ export default {
       default: () => ({}),
     },
     isArrayItem: {
+      type: Boolean,
+      default: false,
+    },
+    tabbed: {
       type: Boolean,
       default: false,
     },
@@ -147,6 +152,9 @@ export default {
         return JsonSchemaObjectField;
       }
       if (this.schema.type === 'array') {
+        if (this.isTabbedObjectArray) {
+          return JsonSchemaTabbedArrayField;
+        }
         return JsonSchemaArrayField;
       }
       if (this.isSecretRef) {
@@ -177,6 +185,9 @@ export default {
       }
 
       if (this.schema.type === 'array') {
+        const tabbedProps = this.isTabbedObjectArray
+          ? { labelProperty: this.schema['x-ui-hint']?.labelProperty || 'name' }
+          : {};
         return {
           ...baseProps,
           value: this.value,
@@ -184,6 +195,7 @@ export default {
           propertyName: this.propertyName,
           validationErrors: this.validationErrors,
           validationError: this.validationError,
+          ...tabbedProps,
         };
       }
 
@@ -218,6 +230,19 @@ export default {
         trim:
           this.schema.type === 'string' && this.schema.format !== 'password',
       };
+    },
+    isTabbedArray() {
+      return (
+        this.schema.type === 'array' &&
+        (this.tabbed || this.schema['x-ui-hint']?.layout === 'tabs')
+      );
+    },
+    isTabbedObjectArray() {
+      return (
+        this.isTabbedArray &&
+        (this.schema.items?.type === 'object' ||
+          !!this.schema.items?.properties)
+      );
     },
     enumOptions() {
       const labels = this.localizedSchema.enumLabels || {};

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -1,0 +1,301 @@
+<template>
+  <div>
+    <showdown
+      v-if="localizedDescription"
+      :markdown="localizedDescription"
+      class="form-text text-muted small mb-2 d-block"
+    />
+
+    <b-nav v-if="currentValue.length" tabs>
+      <n-nav-item
+        v-for="(item, index) in currentValue"
+        :key="itemKeys[index]"
+        :active="activeIndex === index"
+        :class="{ 'text=danger': hasItemValidationError(index) }"
+        @click="selectTab(index)"
+      >
+        <i
+          v-if="hasItemValidationError(index)"
+          class="fa fa-exclamation-circle text-danger mr-1"
+          :title="$t('validation.schema.validation_failed')"
+          area-hidden="true"
+        ></i>
+        {{ itemLabel(item, index) }}
+      </n-nav-item>
+    </b-nav>
+
+    <div v-if="currentValue.length" class="pt-3">
+      <div class="text-right mb-2">
+        <b-button
+          variant="outline-danger"
+          size="sm"
+          :disabled="!canRemoveItems"
+          :aria-label="removeItemAriaLabel(activeItem activeIndex)"
+          @click="removeItem(activeIndex)"
+        >
+          <i class="fa fa-trash mr-1" area-hidden="true"></i>
+          {{ removeItemAriaLabel(activeItem activeIndex) }}
+        </b-button>
+      </div>
+      <div v-for="(propSchema, propName) in itemProperties" :key="propName">
+        <json-schema-form-field
+          :schema="enrichSchema(propSchema, propName, itemSchema)"
+          :property-name="`${propertyName}[${activeIndex}].${propName}`"
+          :value="activeItem[propName]"
+          :validation-error="activeItemValidationErrors[propName]"
+          :validation-errors="activeNestedErrorMap[propName] || {}"
+          :is-array-item="true"
+          @input="onPropertyChange(propName, $event)"
+        />
+      </div>
+    </div>
+
+    <p v-else class="text-muted mb-2">
+      {{ emptyMessage }}
+    </p>
+
+    <b-button
+      variant="outline-primary"
+      size="sm"
+      :disabled="isMaxItemsReached"
+      @click="addItem"
+    >
+      <i class="fa fa-plus"></i>
+      {{ addButtonText }}
+    </b-button>
+
+    <small
+      v-if="!validationError && (schema.minItems || schema.maxItems)"
+      class="form-text text-muted d-block mt-1"
+    >
+      <span v-if="schema.minItems">
+        {{
+          $tc('admin.json_schema_form.min_items', schema.minItems, {
+            n: schema.minItems,
+          })
+        }}
+      </span>
+      <span v-if="schema.maxItems">
+        {{
+          $tc('admin.json_schema_form.max_items', schema.maxItems, {
+            n: schema.maxItems,
+          })
+        }}
+      </span>
+    </small>
+
+    <div v-if="validationError" class="invalid-feedback d-block">
+      {{ validationError }}
+    </div>
+  </div>
+</template>
+
+<script>
+import JsonSchemaFormField from './JsonSchemaFormField.vue';
+import Showdown from './Showdown.vue';
+import {
+  enrichSchema,
+  getDefaultValue,
+  buildNestedValidationErrorMap,
+} from '@/shared/jsonSchemaForm';
+
+let nextItemId = 0;
+const nextId = () => {
+  nextItemId += 1;
+  return nextItemId;
+};
+
+export default {
+  name: 'JsonSchemaTabbedArrayField',
+  components: {
+    JsonSchemaFormField,
+    Showdown,
+  },
+  props: {
+    schema: {
+      type: Object,
+      required: true,
+    },
+    propertyName: {
+      type: String,
+      required: true,
+    },
+    value: {
+      type: Array,
+      default: () => [],
+    },
+    validationErrors: {
+      type: Object,
+      default: () => ({}),
+    },
+    validationError: {
+      type: String,
+      default: null,
+    },
+    labelProperty: {
+      type: String,
+      default: 'name',
+    },
+  },
+  data() {
+    const arr = this.value || [];
+    return {
+      activeIndex: 0,
+      itemKeys: arr.map(() => nextId()),
+    };
+  },
+  computed: {
+    currentValue() {
+      return this.value || [];
+    },
+    itemSchema() {
+      return this.schema.items || { type: 'object', properties: {} };
+    },
+    itemProperties() {
+      return this.itemSchema.properties || {};
+    },
+    activeItem() {
+      return this.currentValue[this.activeIndex] || {};
+    },
+    localizedDescription() {
+      return (
+        this.schema['x-i18n']?.[this.$i18n.locale]?.description ??
+        this.schema.description
+      );
+    },
+    itemTitle() {
+      return (
+        this.itemSchema['x-i18n']?.[this.$i18n.locale]?.title ||
+        this.itemSchema.title ||
+        this.$t('message.item')
+      );
+    },
+    itemCollectionLabel() {
+      const label = String(this.itemTitle).toLowerCase();
+      return label.endsWith('s') ? label : `${label}s`
+    },
+    addButtonText() {
+      return this.$t('message.add_item', { item: this.itemTitle });
+    },
+    emptyMessage() {
+      return this.$t('admin.json_schema_form.no_items_configured', {
+        item: this.itemCollectionLabel
+      });
+    },
+    isMaxItemsReached() {
+      return (
+        this.schema.maxItems !== undefined &&
+        this.currentValue.length >= this.schema.maxItems
+      );
+    },
+    canRemoveItems() {
+      return this.currentValue.length > (this.schema.minItems ?? 1);
+    },
+    nestedErrorMap() {
+      return buildNestedValidationErrorMap(this.validationErrors);
+    },
+    activeItemValidationErrors() {
+      return this.nestedErrorMap[this.activeIndex] || {};
+    },
+    activeNestedErrorMap() {
+      return buildNestedValidationErrorMap(this.activeItemValidationErrors);
+    },
+  },
+  watch: {
+    value(newValue) {
+      const arr = newValue || [];
+      if (arr.length !== this.itemKeys.length) {
+        this.itemKeys = arr.map(() => nextId());
+      }
+      this.activeIndex = Math.min(
+        this.activeIndex,
+        Math.max(0, arr.length - 1)
+      );
+    },
+  },
+  methods: {
+    enrichSchema,
+    selectTab(index) {
+      this.activeIndex = index;
+    },
+    itemLabel(item, index) {
+      const label = item?.[this.labelProperty];
+      if (typeof label === 'string' && label.trim()) {
+        return label;
+      }
+      return this.$t('admin.json_schema_form.item_number', {
+        item: this.itemTitle,
+        n: index + 1,
+      });
+    },
+    hasItemValidationError() {
+      return (
+        Object.keys(this.nestedErrorMap[index] || {}).length > 0 ||
+        Object.prototype.hasOwnProperty.call(this.validationErrors, index)
+      );
+    },
+    defaultItem() {
+
+    },
+    addItem() {
+      const defaultValue = getDefaultValue(this.itemSchema, {
+        arrayItem: true,
+      });
+      const newArray = [...this.currentValue, defaultValue];
+      this.itemKeys = [...this.itemKeys, nextId()];
+      this.$emit('input', newArray);
+    },
+    removeItem(index) {
+      const newArray = this.currentValue.filter((_, i) => i !== index);
+      this.itemKeys = this.itemKeys.filter((_, i) => i !== index);
+      this.$emit('input', newArray);
+    },
+    onItemChange(index, newValue) {
+      const newArray = this.currentValue.slice();
+      newArray[index] = newValue;
+      this.$emit('input', newArray);
+    },
+    removeItemAriaLabel(item, index) {
+      if (
+        (typeof item === 'string' || typeof item === 'number') &&
+        item !== '' &&
+        item !== null
+      ) {
+        return this.$t('admin.json_schema_form.remove_named_item_aria', {
+          name: item,
+        });
+      }
+      return this.$t('admin.json_schema_form.remove_item_aria', {
+        n: index + 1,
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.json-schema-array-row {
+  display: flex;
+  align-items: flex-start;
+}
+.json-schema-array-row__field {
+  flex-grow: 1;
+  margin-right: 0.5rem;
+}
+.json-schema-array-row__remove {
+  padding: 0.25rem 0.5rem;
+}
+@media (max-width: 576px) {
+  .json-schema-array-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .json-schema-array-row__field {
+    margin-right: 0;
+    margin-bottom: 0.25rem;
+  }
+  .json-schema-array-row__remove {
+    align-self: flex-end;
+  }
+}
+</style>

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -7,7 +7,7 @@
     />
 
     <b-nav v-if="currentValue.length" tabs>
-      <n-nav-item
+      <b-nav-item
         v-for="(item, index) in currentValue"
         :key="itemKeys[index]"
         :active="activeIndex === index"
@@ -21,7 +21,7 @@
           area-hidden="true"
         ></i>
         {{ itemLabel(item, index) }}
-      </n-nav-item>
+      </b-nav-item>
     </b-nav>
 
     <div v-if="currentValue.length" class="pt-3">
@@ -33,7 +33,7 @@
           :aria-label="removeItemAriaLabel(activeItem, activeIndex)"
           @click="removeItem(activeIndex)"
         >
-          <i class="fa fa-trash mr-1" area-hidden="true"></i>
+          <i class="fa fa-trash mr-1" aria-hidden="true"></i>
           {{ removeItemAriaLabel(activeItem, activeIndex) }}
         </b-button>
       </div>
@@ -228,7 +228,7 @@ export default {
         n: index + 1,
       });
     },
-    hasItemValidationError() {
+    hasItemValidationError(index) {
       return (
         Object.keys(this.nestedErrorMap[index] || {}).length > 0 ||
         Object.prototype.hasOwnProperty.call(this.validationErrors, index)

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -235,34 +235,67 @@ export default {
       );
     },
     defaultItem() {
+      const defaultItem = getDefaultValue(this.itemSchema, {arrayItem: true});
+      const item = defaultItem && typeof defaultItem === 'object' ? defaultItem : {};
 
+      Object.entries(this.itemProperties).forEach(([propName, propSchema]) => {
+        if (item[propName] === undefined) {
+          item[propName] = getDefaultValue(propSchema);
+        }
+      });
+
+      if (this.itemProperties[this.labelProperty]) {
+        item[this.labelProperty] = this.uniqueLabel();
+      }
+      return item;
+    },
+    uniqueLabel() {
+      const labels = new Set(
+        this.currentValue.map((item) => item?.[this.labelProperty])
+          .filter((label) => typeof label === 'string')
+          .map((label) => label.trim())
+      );
+      let suffix = 1;
+      let label = 'new-source';
+      while (labels.has(label)) {
+        suffix += 1;
+        label = `new-source-'${suffix}`;
+      }
+      return label;
     },
     addItem() {
-      const defaultValue = getDefaultValue(this.itemSchema, {
-        arrayItem: true,
-      });
-      const newArray = [...this.currentValue, defaultValue];
+      if (this.isMaxItemsReached) {
+        return;
+      }
+      const newArray = [...this.currentValue, this.defaultItem()];
       this.itemKeys = [...this.itemKeys, nextId()];
+      this.activeIndex = newArray.length - 1;
       this.$emit('input', newArray);
     },
     removeItem(index) {
+      if (!this.canRemoveItems) {
+        return;
+      }
       const newArray = this.currentValue.filter((_, i) => i !== index);
       this.itemKeys = this.itemKeys.filter((_, i) => i !== index);
+      if (index < this.activeIndex) {
+        this.activeIndex -= 1;
+      } else {
+        this.activeIndex = Math.min(this.activeIndex, Math.max(0, newArray.length - 1));
+      }
       this.$emit('input', newArray);
     },
-    onItemChange(index, newValue) {
+    onPropertyChange(propName, propValue) {
+      const newItem = { ...this.activeItem, [propName]: propValue };
       const newArray = this.currentValue.slice();
-      newArray[index] = newValue;
+      newArray[this.activeIndex] = newItem;
       this.$emit('input', newArray);
     },
     removeItemAriaLabel(item, index) {
-      if (
-        (typeof item === 'string' || typeof item === 'number') &&
-        item !== '' &&
-        item !== null
-      ) {
+      const label = item?.[this.labelProperty];
+      if (typeof label === 'string' && label.trim()) {
         return this.$t('admin.json_schema_form.remove_named_item_aria', {
-          name: item,
+          name: label,
         });
       }
       return this.$t('admin.json_schema_form.remove_item_aria', {

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -30,11 +30,11 @@
           variant="outline-danger"
           size="sm"
           :disabled="!canRemoveItems"
-          :aria-label="removeItemAriaLabel(activeItem activeIndex)"
+          :aria-label="removeItemAriaLabel(activeItem, activeIndex)"
           @click="removeItem(activeIndex)"
         >
           <i class="fa fa-trash mr-1" area-hidden="true"></i>
-          {{ removeItemAriaLabel(activeItem activeIndex) }}
+          {{ removeItemAriaLabel(activeItem, activeIndex) }}
         </b-button>
       </div>
       <div v-for="(propSchema, propName) in itemProperties" :key="propName">

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -11,58 +11,55 @@
         v-for="(item, index) in currentValue"
         :key="itemKeys[index]"
         :active="activeIndex === index"
-        :class="{ 'text=danger': hasItemValidationError(index) }"
+        :class="{ 'text-danger': hasItemValidationError(index) }"
         @click="selectTab(index)"
       >
         <i
           v-if="hasItemValidationError(index)"
           class="fa fa-exclamation-circle text-danger mr-1"
           :title="$t('validation.schema.validation_failed')"
-          area-hidden="true"
+          aria-hidden="true"
         ></i>
         {{ itemLabel(item, index) }}
       </b-nav-item>
     </b-nav>
 
     <div v-if="currentValue.length" class="pt-3">
-      <div class="text-right mb-2">
-        <b-button
-          variant="outline-danger"
-          size="sm"
-          :disabled="!canRemoveItems"
-          :aria-label="removeItemAriaLabel(activeItem, activeIndex)"
-          @click="removeItem(activeIndex)"
-        >
-          <i class="fa fa-trash mr-1" aria-hidden="true"></i>
-          {{ removeItemAriaLabel(activeItem, activeIndex) }}
-        </b-button>
-      </div>
-      <div v-for="(propSchema, propName) in itemProperties" :key="propName">
-        <json-schema-form-field
-          :schema="enrichSchema(propSchema, propName, itemSchema)"
-          :property-name="`${propertyName}[${activeIndex}].${propName}`"
-          :value="activeItem[propName]"
-          :validation-error="activeItemValidationErrors[propName]"
-          :validation-errors="activeNestedErrorMap[propName] || {}"
-          :is-array-item="true"
-          @input="onPropertyChange(propName, $event)"
-        />
-      </div>
+      <json-schema-object-field
+        :schema="itemSchema"
+        :property-name="`${propertyName}[${activeIndex}]`"
+        :value="activeItem"
+        :validation-errors="activeItemValidationErrors"
+        @input="onItemChange"
+      />
     </div>
 
     <p v-else class="text-muted mb-2">
       {{ emptyMessage }}
     </p>
 
-    <b-button
-      variant="outline-primary"
-      size="sm"
-      :disabled="isMaxItemsReached"
-      @click="addItem"
-    >
-      <i class="fa fa-plus"></i>
-      {{ addButtonText }}
-    </b-button>
+    <div class="d-flex justify-content-between align-items-center mt-3">
+      <b-button
+        variant="outline-primary"
+        size="sm"
+        :disabled="isMaxItemsReached"
+        @click="addItem"
+      >
+        <i class="fa fa-plus"></i>
+        {{ addButtonText }}
+      </b-button>
+
+      <b-button
+        variant="outline-danger"
+        size="sm"
+        :disabled="!canRemoveItems"
+        :aria-label="removeItemAriaLabel(activeItem, activeIndex)"
+        @click="removeItem(activeIndex)"
+      >
+        <i class="fa fa-trash mr-1" aria-hidden="true"></i>
+        {{ removeItemAriaLabel(activeItem, activeIndex) }}
+      </b-button>
+    </div>
 
     <small
       v-if="!validationError && (schema.minItems || schema.maxItems)"
@@ -290,10 +287,9 @@ export default {
       }
       this.$emit('input', newArray);
     },
-    onPropertyChange(propName, propValue) {
-      const newItem = { ...this.activeItem, [propName]: propValue };
-      const newArray = this.currentValue.slice();
-      newArray[this.activeIndex] = newItem;
+    onItemChange(item) {
+      const newArray = [...this.currentValue];
+      newArray[this.activeIndex] = item;
       this.$emit('input', newArray);
     },
     removeItemAriaLabel(item, index) {

--- a/src/views/components/JsonSchemaTabbedArrayField.vue
+++ b/src/views/components/JsonSchemaTabbedArrayField.vue
@@ -172,14 +172,14 @@ export default {
     },
     itemCollectionLabel() {
       const label = String(this.itemTitle).toLowerCase();
-      return label.endsWith('s') ? label : `${label}s`
+      return label.endsWith('s') ? label : `${label}s`;
     },
     addButtonText() {
       return this.$t('message.add_item', { item: this.itemTitle });
     },
     emptyMessage() {
       return this.$t('admin.json_schema_form.no_items_configured', {
-        item: this.itemCollectionLabel
+        item: this.itemCollectionLabel,
       });
     },
     isMaxItemsReached() {
@@ -209,7 +209,7 @@ export default {
       }
       this.activeIndex = Math.min(
         this.activeIndex,
-        Math.max(0, arr.length - 1)
+        Math.max(0, arr.length - 1),
       );
     },
   },
@@ -235,8 +235,9 @@ export default {
       );
     },
     defaultItem() {
-      const defaultItem = getDefaultValue(this.itemSchema, {arrayItem: true});
-      const item = defaultItem && typeof defaultItem === 'object' ? defaultItem : {};
+      const defaultItem = getDefaultValue(this.itemSchema, { arrayItem: true });
+      const item =
+        defaultItem && typeof defaultItem === 'object' ? defaultItem : {};
 
       Object.entries(this.itemProperties).forEach(([propName, propSchema]) => {
         if (item[propName] === undefined) {
@@ -251,9 +252,10 @@ export default {
     },
     uniqueLabel() {
       const labels = new Set(
-        this.currentValue.map((item) => item?.[this.labelProperty])
+        this.currentValue
+          .map((item) => item?.[this.labelProperty])
           .filter((label) => typeof label === 'string')
-          .map((label) => label.trim())
+          .map((label) => label.trim()),
       );
       let suffix = 1;
       let label = 'new-source';
@@ -281,7 +283,10 @@ export default {
       if (index < this.activeIndex) {
         this.activeIndex -= 1;
       } else {
-        this.activeIndex = Math.min(this.activeIndex, Math.max(0, newArray.length - 1));
+        this.activeIndex = Math.min(
+          this.activeIndex,
+          Math.max(0, newArray.length - 1),
+        );
       }
       this.$emit('input', newArray);
     },


### PR DESCRIPTION
### Description

Flat single OSV source is being converted to multi-source (refer backend PR). 

This adds a generic tabbed renderer for object arrays and opts the OSV config page into it. Each OSV data source entry gets its own config tab, with add/remove actions.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/6331

### Additional Details

This depends on backend changes https://github.com/DependencyTrack/dependency-track/pull/7113

<img width="1512" height="828" alt="Screenshot 2026-08-27 at 15 31 46" src="https://github.com/user-attachments/assets/e9a359fd-363d-4707-b863-541ab8cc79f7" />

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
