### PR TITLE
Add tag exclusion toggle to policy scope

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -118,6 +118,7 @@
     "enabled": "Aktiviert",
     "enabled_for_tags": "Aktiviert für Tags",
     "events": null,
+    "exclude_tags": "Ausgeschlossene Tags",
     "extension_name": "Erweiterungsname",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Interne Komponenten",
     "internal_identification_error": "Beim Warteschlangenvorgang für die interne Komponentenidentifikation ist ein Fehler aufgetreten. Weitere Informationen finden Sie in den Serverprotokollen.",
     "internal_identification_queued": "Interne Komponentenidentifikation in der Warteschlange",
+    "invert_tag_match": "Ausgewählte Tags ausschließen",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -118,6 +118,7 @@
     "enabled": "Enabled",
     "enabled_for_tags": "Enabled for tags",
     "events": "Events",
+    "exclude_tags": "Excluded Tags",
     "extension_name": "Extension name",
     "extension_no_config": "This extension does not support configuration.",
     "failure": "Failure",
@@ -158,6 +159,7 @@
     "internal_components": "Internal Components",
     "internal_identification_error": "An error occurred queueing internal component identification. Check server logs for details",
     "internal_identification_queued": "Internal component identification queued",
+    "invert_tag_match": "Exclude selected tags",
     "json_schema_form": {
       "max_items": "Maximum {n} item. | Maximum {n} items.",
       "min_items": "Minimum {n} item. | Minimum {n} items.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -118,6 +118,7 @@
     "enabled": "Activado",
     "enabled_for_tags": "Habilitado para etiquetas",
     "events": null,
+    "exclude_tags": "Etiquetas excluidas",
     "extension_name": "Nombre de extensión",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Componentes internos",
     "internal_identification_error": "Se produjo un error al poner en cola la identificación de componentes internos. Consulte los registros del servidor para obtener más detalles",
     "internal_identification_queued": "Identificación de componentes internos en cola",
+    "invert_tag_match": "Excluir etiquetas seleccionadas",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -118,6 +118,7 @@
     "enabled": "Activé",
     "enabled_for_tags": "Activé pour les balises",
     "events": null,
+    "exclude_tags": "Tags exclus",
     "extension_name": "Nom d'extension",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Composants internes",
     "internal_identification_error": "Une erreur s'est produite lors de la mise en file d'attente de l'identification des composants internes. Vérifiez les journaux du serveur pour plus de détails",
     "internal_identification_queued": "Identification des composants internes en file d'attente",
+    "invert_tag_match": "Exclure les balises sélectionnées",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -118,6 +118,7 @@
     "enabled": "सक्रिय",
     "enabled_for_tags": "टैग के लिए सक्षम",
     "events": null,
+    "exclude_tags": "बाहर रखा टैग",
     "extension_name": "एक्सटेंशन का नाम",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "आंतरिक घटक",
     "internal_identification_error": "आंतरिक घटक पहचान को कतारबद्ध करते समय त्रुटि हुई। विवरण के लिए सर्वर लॉग देखें",
     "internal_identification_queued": "आंतरिक घटक पहचान पंक्तिबद्ध",
+    "invert_tag_match": "चयनित टैग को बाहर करें",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -118,6 +118,7 @@
     "enabled": "Abilitato",
     "enabled_for_tags": "Abilitato per i tag",
     "events": null,
+    "exclude_tags": "Tag esclusi",
     "extension_name": "Nome estensione",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Componenti interni",
     "internal_identification_error": "Si è verificato un errore nell'accodamento dell'identificazione del componente interno. Controlla i log del server per i dettagli",
     "internal_identification_queued": "Identificazione del componente interno in coda",
+    "invert_tag_match": "Escludi i tag selezionati",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -118,6 +118,7 @@
     "enabled": "有効",
     "enabled_for_tags": "タグに対して有効化",
     "events": null,
+    "exclude_tags": "除外されたタグ",
     "extension_name": "拡張機能名",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "内部コンポーネント",
     "internal_identification_error": "内部コンポーネント識別のキューイング中にエラーが発生しました。詳細についてはサーバーログを確認してください。",
     "internal_identification_queued": "内部コンポーネント識別がキューに登録されました",
+    "invert_tag_match": "選択したタグを除外します",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -118,6 +118,7 @@
     "enabled": "활성화됨",
     "enabled_for_tags": "다음 태그에 대해 활성화",
     "events": "이벤트",
+    "exclude_tags": "제외된 태그",
     "extension_name": "확장 이름",
     "extension_no_config": "이 확장은 설정을 지원하지 않습니다.",
     "failure": "실패",
@@ -158,6 +159,7 @@
     "internal_components": "내부 컴포넌트",
     "internal_identification_error": "내부 컴포넌트 식별 작업을 큐에 등록하는 중 오류가 발생했습니다. 자세한 내용은 서버 로그를 확인하세요",
     "internal_identification_queued": "내부 컴포넌트 식별 작업이 큐에 등록되었습니다",
+    "invert_tag_match": "선택한 태그 제외",
     "json_schema_form": {
       "max_items": "최대 {n}개 항목. | 최대 {n}개 항목.",
       "min_items": "최소 {n}개 항목. | 최소 {n}개 항목.",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -118,6 +118,7 @@
     "enabled": "Włączony",
     "enabled_for_tags": "Włączono dla tagów",
     "events": null,
+    "exclude_tags": "Wykluczone tagi",
     "extension_name": "Nazwa rozszerzenia",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Komponenty wewnętrzne",
     "internal_identification_error": "Wystąpił błąd podczas kolejkowania identyfikacji komponentów wewnętrznych. Sprawdź dzienniki serwera, aby uzyskać szczegółowe informacje",
     "internal_identification_queued": "Wewnętrzna identyfikacja komponentów w kolejce",
+    "invert_tag_match": "Wyklucz wybrane tagi",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -118,6 +118,7 @@
     "enabled": "Habilitado",
     "enabled_for_tags": "Ativado para tags",
     "events": null,
+    "exclude_tags": "Tags excluídas",
     "extension_name": "Nome da extensão",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Componentes Internos",
     "internal_identification_error": "Ocorreu um erro ao enfileirar a identificação do componente interno. Verifique os logs do servidor para obter detalhes",
     "internal_identification_queued": "Identificação de componente interno na fila",
+    "invert_tag_match": "Exclua tags selecionadas",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -118,6 +118,7 @@
     "enabled": "Habilitado",
     "enabled_for_tags": "Ativado para tags",
     "events": null,
+    "exclude_tags": "Tags excluídas",
     "extension_name": "Nome da extensão",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Componentes Internos",
     "internal_identification_error": "Ocorreu um erro ao enfileirar a identificação do componente interno. Verifique os logs do servidor para obter detalhes",
     "internal_identification_queued": "Identificação de componente interno na fila",
+    "invert_tag_match": "Exclua tags selecionadas",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -118,6 +118,7 @@
     "enabled": "Включено",
     "enabled_for_tags": "Включено для тегов",
     "events": null,
+    "exclude_tags": "Исключённые теги",
     "extension_name": "Имя расширения",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Внутренние компоненты",
     "internal_identification_error": "Произошла ошибка при постановке задачи по идентификации внутренних компонентов в очередь. Проверьте логи сервера для получения деталей.",
     "internal_identification_queued": "Идентификация внутренних компонентов поставлена в очередь",
+    "invert_tag_match": "Исключить выбранные теги",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -118,6 +118,7 @@
     "enabled": "Увімкнено",
     "enabled_for_tags": "Увімкнено для тегів",
     "events": null,
+    "exclude_tags": "Виключені теги",
     "extension_name": "Назва розширення",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "Внутрішні компоненти",
     "internal_identification_error": "Сталася помилка при постановці в чергу ідентифікації внутрішнього компонента. Перевірте журнали сервера для отримання деталей",
     "internal_identification_queued": "Ідентифікацію внутрішнього компонента поставлено в чергу",
+    "invert_tag_match": "Виключити вибрані теги",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -118,6 +118,7 @@
     "enabled": "已啟用",
     "enabled_for_tags": "對標籤啟用",
     "events": "活動",
+    "exclude_tags": "排除的標籤",
     "extension_name": "擴充名",
     "extension_no_config": "此擴充不支援配置。",
     "failure": "失敗",
@@ -158,6 +159,7 @@
     "internal_components": "內部元件",
     "internal_identification_error": "排入內部元件識別佇列時發生錯誤。請檢視伺服器日誌了解詳細資訊",
     "internal_identification_queued": "內部元件識別已排入佇列",
+    "invert_tag_match": "排除選取的標籤",
     "json_schema_form": {
       "max_items": "最多 {n} 項。 |最多 {n} 個項目。",
       "min_items": "最少 {n} 項。 |最少 {n} 項。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -118,6 +118,7 @@
     "enabled": "已启用",
     "enabled_for_tags": "已对标签启用",
     "events": null,
+    "exclude_tags": "排除的标签",
     "extension_name": "扩展名称",
     "extension_no_config": null,
     "failure": null,
@@ -158,6 +159,7 @@
     "internal_components": "内部组件",
     "internal_identification_error": "内部组件识别入队时发生错误。请查看服务器日志了解详细信息",
     "internal_identification_queued": "内部组件识别已加入队列",
+    "invert_tag_match": "排除选定的标签",
     "json_schema_form": {
       "max_items": null,
       "min_items": null,

--- a/src/views/policy/PolicyList.vue
+++ b/src/views/policy/PolicyList.vue
@@ -172,7 +172,12 @@ export default {
                         </b-col>
                       </b-row>
                     </div>
-                    <b-form-group v-if="limitToVisible === true" id="tagLimitsList" :label="this.$t('admin.limit_to_tags')">
+                    <b-form-group v-if="limitToVisible === true" id="tagLimitsList" :label="invertTagMatch ? this.$t('admin.exclude_tags') : this.$t('admin.limit_to_tags')">
+                      <b-input-group-form-switch
+                        id="isInvertTagMatch"
+                        :label="$t('admin.invert_tag_match')"
+                        v-model="invertTagMatch"
+                      />
                       <div class="list-group">
                         <span v-for="tag in tags">
                           <actionable-list-group-item :value="formatLabel(tag.name, tag.id)" :delete-icon="true" v-on:actionClicked="deleteTagLimiter(tag.name)"/>
@@ -223,6 +228,7 @@ export default {
                 tags: row.tags,
                 includeChildren: row.includeChildren,
                 onlyLatestProjectVersion: row.onlyLatestProjectVersion,
+                invertTagMatch: row.invertTagMatch || false,
               };
             },
             methods: {
@@ -267,6 +273,7 @@ export default {
                     violationState: this.violationState,
                     includeChildren: this.includeChildren,
                     onlyLatestProjectVersion: this.onlyLatestProjectVersion,
+                    invertTagMatch: this.invertTagMatch,
                   })
                   .then((response) => {
                     // prevent that "limit to" details are hidden after updates where table does not need to refresh
@@ -307,6 +314,7 @@ export default {
                 this.conditions = policy.policyConditions;
                 this.includeChildren = policy.includeChildren;
                 this.onlyLatestProjectVersion = policy.onlyLatestProjectVersion;
+                this.invertTagMatch = policy.invertTagMatch;
               },
               deleteProjectLimiter: function (projectUuid) {
                 let url = `${this.$api.BASE_URL}/${this.$api.URL_POLICY}/${this.policy.uuid}/project/${projectUuid}`;

--- a/src/views/policy/PolicyList.vue
+++ b/src/views/policy/PolicyList.vue
@@ -406,6 +406,9 @@ export default {
               onlyLatestProjectVersion() {
                 this.updatePolicy();
               },
+              invertTagMatch() {
+                this.updatePolicy();
+              },
             },
           });
         },


### PR DESCRIPTION
### Description

DependencyTrack/dependency-track#7176 added `invertTagMatch`, which applies a policy to every project that does not carry its tags. This exposes it in the policy scope UI.

The switch sits next to the existing `includeChildren` and `onlyLatestProjectVersion` switches, and the tag list label swaps between "Limit to tags" and "Excluded tags" so it is clear which way the tags are being applied.

### Addressed Issue

Frontend side of https://github.com/DependencyTrack/dependency-track/issues/5042

### Additional Details

This replaces #1275, which was raised against master before the v5 restructure. Same approach, with one addition: `syncVariables` now also assigns `invertTagMatch`, otherwise the switch goes stale after saving, since the other scope fields are assigned there and it was not.

Translations are the ones from #1275.

### Checklist

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/frontend/blob/main/CONTRIBUTING.md)