### PR TITLE
feat(oidc): implement RP-Initiated Logout

### DIFF
--- a/src/containers/DefaultHeaderProfileDropdown.vue
+++ b/src/containers/DefaultHeaderProfileDropdown.vue
@@ -32,6 +32,7 @@
 <script>
 import { HeaderDropdown as AppHeaderDropdown } from '@coreui/vue';
 import EventBus from '../shared/eventbus';
+import { clearOidcSession, getOidcUserManager } from '../shared/oidc';
 import globalVarsMixin from '../mixins/globalVarsMixin';
 import LocalePicker from '@/views/components/LocalePicker.vue';
 
@@ -67,7 +68,24 @@ export default {
         localStorage.removeItem('sessionInvalidate');
         // Clear token and permissions.
         EventBus.$emit('authenticated', null);
-        this.$router.replace({ name: 'Login' });
+
+        const idToken = clearOidcSession();
+        const oidcUserManager = idToken === null ? null : getOidcUserManager();
+        if (oidcUserManager === null) {
+          // Not an OIDC session, or OIDC is no longer configured.
+          this.$router.replace({ name: 'Login' });
+          return;
+        }
+
+        // RP-Initiated Logout, see
+        // https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+        // Without it the session at the identity provider survives, and the
+        // next click on the OpenID button re-authenticates silently.
+        oidcUserManager
+          .signoutRedirect({ id_token_hint: idToken || undefined })
+          .catch(() => {
+            this.$router.replace({ name: 'Login' });
+          });
       });
     },
     canChangePassword: function () {

--- a/src/shared/oidc.js
+++ b/src/shared/oidc.js
@@ -1,0 +1,80 @@
+import Oidc from 'oidc-client';
+import Vue from 'vue';
+import { getContextPath } from './utils';
+
+/**
+ * Key under which the ID token of the current session is recorded, if that
+ * session was established via OIDC.
+ *
+ * Neither of the obvious alternatives works at logout time:
+ *   - /api/v1/user/self does not expose the principal type. Managed users can
+ *     be identified by the presence of `suspended`, but LDAP users are
+ *     indistinguishable from OIDC users that way.
+ *   - UserManager.getUser() returns null, because the OIDC user is removed
+ *     from the web storage right after the token exchange (see Login.vue).
+ */
+const OIDC_SESSION_KEY = 'oidcSession';
+
+let userManager = null;
+
+/**
+ * Whether the frontend is configured for OIDC.
+ */
+export function isOidcConfigured() {
+  const oidc = Vue.prototype.$oidc;
+  return Boolean(oidc && oidc.ISSUER && oidc.CLIENT_ID && oidc.SCOPE);
+}
+
+/**
+ * Lazily creates the shared UserManager. Returns null when OIDC is not
+ * configured, so callers can fall back to local-only behavior.
+ */
+export function getOidcUserManager() {
+  if (userManager !== null) {
+    return userManager;
+  }
+  if (!isOidcConfigured()) {
+    return null;
+  }
+
+  const oidc = Vue.prototype.$oidc;
+  const baseUrl = `${window.location.origin}${getContextPath()}`;
+
+  userManager = new Oidc.UserManager({
+    userStore: new Oidc.WebStorageStateStore(),
+    authority: oidc.ISSUER,
+    client_id: oidc.CLIENT_ID,
+    redirect_uri: `${baseUrl}/static/oidc-callback.html`,
+    post_logout_redirect_uri: baseUrl,
+    response_type: oidc.FLOW === 'implicit' ? 'token id_token' : 'code',
+    scope: oidc.SCOPE,
+    loadUserInfo: false,
+  });
+
+  return userManager;
+}
+
+/**
+ * Records that the current session was established via OIDC, retaining the ID
+ * token for use as id_token_hint during RP-Initiated Logout.
+ */
+export function markOidcSession(idToken) {
+  sessionStorage.setItem(OIDC_SESSION_KEY, idToken || '');
+}
+
+/**
+ * Whether the current session was established via OIDC.
+ */
+export function isOidcSession() {
+  return sessionStorage.getItem(OIDC_SESSION_KEY) !== null;
+}
+
+/**
+ * Clears the recorded OIDC session and returns the retained ID token, or null
+ * if the current session was not established via OIDC.
+ */
+export function clearOidcSession() {
+  const idToken = sessionStorage.getItem(OIDC_SESSION_KEY);
+  sessionStorage.removeItem(OIDC_SESSION_KEY);
+  return idToken === null ? null : idToken;
+}

--- a/src/views/pages/Login.vue
+++ b/src/views/pages/Login.vue
@@ -101,13 +101,18 @@
 
 <script>
 import axios from 'axios';
-import Oidc from 'oidc-client';
+import {
+  getOidcUserManager,
+  isOidcConfigured,
+  markOidcSession,
+} from '../../shared/oidc';
+
 // bootstrap-table still relies on jQuery for ajax calls, even though there's a supported Vue wrapper for it.
 import { ValidationObserver } from 'vee-validate';
 import BValidatedInputGroupFormInput from '../../forms/BValidatedInputGroupFormInput';
 import InformationalModal from '../modals/InformationalModal';
 import EventBus from '../../shared/eventbus';
-import { getRedirectUrl, getContextPath } from '../../shared/utils';
+import { getRedirectUrl } from '../../shared/utils';
 const qs = require('querystring');
 import common from '../../shared/common';
 import * as permissions from '../../shared/permissions';
@@ -130,19 +135,7 @@ export default {
         password: '',
       },
       oidcAvailable: false,
-      oidcUserManager: new Oidc.UserManager({
-        userStore: new Oidc.WebStorageStateStore(),
-        authority: this.$oidc.ISSUER,
-        client_id: this.$oidc.CLIENT_ID,
-        redirect_uri:
-          getContextPath() !== ''
-            ? `${window.location.origin}${getContextPath()}/static/oidc-callback.html`
-            : `${window.location.origin}/static/oidc-callback.html`,
-        response_type:
-          this.$oidc.FLOW === 'implicit' ? 'token id_token' : 'code',
-        scope: this.$oidc.SCOPE,
-        loadUserInfo: false,
-      }),
+      oidcUserManager: getOidcUserManager(),
       showLoginForm: false,
     };
   },
@@ -230,11 +223,7 @@ export default {
         });
     },
     isOidcAvailableInFrontend() {
-      return (
-        this.oidcUserManager.settings.authority &&
-        this.oidcUserManager.settings.client_id &&
-        this.oidcUserManager.settings.scope
-      );
+      return isOidcConfigured();
     },
     checkOidcAvailability() {
       if (!this.isOidcAvailableInFrontend()) {
@@ -282,7 +271,7 @@ export default {
         this.oidcAvailable = oidcAvailable;
         this.showLoginForm = !oidcAvailable;
 
-        if (!oidcAvailable) {
+        if (!oidcAvailable || this.oidcUserManager === null) {
           return;
         }
 
@@ -308,6 +297,9 @@ export default {
             .post(url, qs.stringify(requestBody), config)
             .then((result) => {
               if (result.status === 200) {
+                // Remember that this session was established via OIDC, so that
+                // logging out can terminate the session at the IdP as well.
+                markOidcSession(oidcUser.id_token);
                 const redirectTo = getRedirectUrl(this.$router);
                 return this.fetchAndCheckPermissions(result.data, redirectTo);
               }


### PR DESCRIPTION
Perform an RP-Initiated Logout as specified in OpenID Connect RP-Initiated Logout 1.0 when, and only when, the current session was established via OIDC. Sessions of managed and LDAP users are unaffected and keep the previous local-only behavior.

The API server does not expose the principal type via /api/v1/user/self, and the OIDC user is intentionally removed from the web storage right after the token exchange. The login view therefore records the ID token in the session storage, which the logout handler consumes as id_token_hint and clears.

The UserManager, previously constructed inline in the login view, moves to src/shared/oidc.js so it can be shared. The end session endpoint is taken from the provider's discovery document, so no additional configuration is required.


### Description

Implements OpenID Connect RP-Initiated Logout.

When a user authenticated via OIDC logs out, the frontend only drops the local
session token and redirects to the login view. The session at the identity
provider stays active, so clicking the OpenID button logs the user straight
back in without presenting any credentials.

Logging out now terminates the session at the identity provider as well, but
only for sessions that were actually established via OIDC. Managed and LDAP
users keep the previous local-only behavior, so this is not a breaking change
and requires no new configuration.

### Addressed Issue

Fixes DependencyTrack/dependency-track#2015

### Additional Details

Determining at logout time whether the current session came from OIDC is not
straightforward:

- `/api/v1/user/self` does not expose the principal type. Managed users can be
  identified by the presence of `suspended`, but LDAP users are
  indistinguishable from OIDC users that way.
- `oidcUserManager.getUser()` returns `null`, because `Login.vue` removes the
  OIDC user right after exchanging the access token for a session token.

`Login.vue` therefore records the ID token in `sessionStorage` at the point
where the token exchange provably succeeded. The logout handler consumes it as
`id_token_hint` and clears it. This tracks *how the current session was
established* rather than the account type, which is the more accurate
condition — a user who happens to have an OIDC account but signed in some
other way should not trigger an IdP logout either.

The `UserManager` was previously constructed inline in `Login.vue` and thus
unreachable from the header component. It moves to `src/shared/oidc.js` as a
lazily created singleton that returns `null` when OIDC is not configured, so
callers can fall back to the local redirect.

Notes:

- No new dependency. `oidc-client` 1.11.5 is already in use and ships
  `signoutRedirect()`.
- No new configuration. `end_session_endpoint` comes from the provider's
  discovery document; `post_logout_redirect_uri` defaults to the frontend
  origin including the context path.
- If the redirect fails, the handler falls back to the local login redirect.

Verified against Keycloak using the code flow: after logging out, clicking the
OpenID button again presents the Keycloak login form instead of silently
re-authenticating.

Operators need to register the frontend origin as a post-logout redirect URI
at their IdP. Happy to open a corresponding PR against the docs repo.


### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly